### PR TITLE
Exit on compiler error

### DIFF
--- a/gui/package.json
+++ b/gui/package.json
@@ -8,6 +8,7 @@
     "d3": "^4.1.0",
     "es6-promise": "^3.2.1",
     "font-awesome": "^4.6.3",
+    "h2oUIKit": "^0.2.0",
     "jquery": "^3.0.0",
     "lodash": "^4.13.1",
     "react": "^15.2.1",
@@ -17,10 +18,10 @@
     "react-router-redux": "^4.0.5",
     "redux": "^3.5.2",
     "redux-thunk": "^2.1.0",
-    "h2oUIKit": "^0.2.0",
     "vis-components": "^0.2.0"
   },
   "devDependencies": {
+    "webpack-fail-plugin": "^1.0.5",
     "browser-sync": "^2.13.0",
     "browser-sync-webpack-plugin": "^1.0.3",
     "css-loader": "^0.23.1",

--- a/gui/webpack.config.js
+++ b/gui/webpack.config.js
@@ -60,7 +60,8 @@ module.exports = {
       host: 'localhost',
       port: 3000,
       server: { baseDir: ['../var/master/www'] }
-    })
+    }),
+    require('webpack-fail-plugin')
   ],
   // more options in the optional tslint object
   tslint: {


### PR DESCRIPTION
Hotfix that causes webpack to propagate tsc compile exit codes, allowing Jenkins to fail correctly on compile errors.
