### PR TITLE
Change limit to 1000 for projects and clusters

### DIFF
--- a/gui/src/Projects/actions/projects.actions.ts
+++ b/gui/src/Projects/actions/projects.actions.ts
@@ -33,7 +33,7 @@ export function receiveClusters(clusters) {
 export function fetchClusters() {
   return (dispatch) => {
     dispatch(requestClusters());
-    Remote.getClusters(0, 5, (error, res) => {
+    Remote.getClusters(0, 1000, (error, res) => {
       dispatch(receiveClusters(res));
     });
   };
@@ -184,7 +184,7 @@ export function registerCluster(address: string) {
 
 export function fetchProjects() {
   return (dispatch) => {
-    Remote.getProjects(0, 5, (error, res) => {
+    Remote.getProjects(0, 1000, (error, res) => {
       dispatch(receiveProjects(<Project[]> res));
     });
   };


### PR DESCRIPTION
- Sets limit way above cardinality for projects and clusters for the time being until we either are satisfied with an unlimited call or settle on some sort of pagination paradigm in the future
