### PR TITLE
Steam 309

### DIFF
--- a/cli2/cli.go
+++ b/cli2/cli.go
@@ -4219,7 +4219,9 @@ Commands:
     $ steam update datasource ...
     $ steam update identity ...
     $ steam update label ...
+    $ steam update model ...
     $ steam update role ...
+    $ steam update service ...
     $ steam update workgroup ...
 `
 
@@ -4230,7 +4232,9 @@ func update(c *context) *cobra.Command {
 	cmd.AddCommand(updateDatasource(c))
 	cmd.AddCommand(updateIdentity(c))
 	cmd.AddCommand(updateLabel(c))
+	cmd.AddCommand(updateModel(c))
 	cmd.AddCommand(updateRole(c))
+	cmd.AddCommand(updateService(c))
 	cmd.AddCommand(updateWorkgroup(c))
 	return cmd
 }
@@ -4391,6 +4395,40 @@ func updateLabel(c *context) *cobra.Command {
 	return cmd
 }
 
+var updateModelHelp = `
+model [?]
+Update Model
+Examples:
+
+    Update a model
+    $ steam update model \
+        --model-id=? \
+        --model-name=?
+
+`
+
+func updateModel(c *context) *cobra.Command {
+	var modelId int64    // No description available
+	var modelName string // No description available
+
+	cmd := newCmd(c, updateModelHelp, func(c *context, args []string) {
+
+		// Update a model
+		err := c.remote.UpdateModel(
+			modelId,   // No description available
+			modelName, // No description available
+		)
+		if err != nil {
+			log.Fatalln(err)
+		}
+		return
+	})
+
+	cmd.Flags().Int64Var(&modelId, "model-id", modelId, "No description available")
+	cmd.Flags().StringVar(&modelName, "model-name", modelName, "No description available")
+	return cmd
+}
+
 var updateRoleHelp = `
 role [?]
 Update Role
@@ -4426,6 +4464,40 @@ func updateRole(c *context) *cobra.Command {
 	cmd.Flags().StringVar(&description, "description", description, "A string description")
 	cmd.Flags().StringVar(&name, "name", name, "A string name.")
 	cmd.Flags().Int64Var(&roleId, "role-id", roleId, "Integer ID of a role in Steam.")
+	return cmd
+}
+
+var updateServiceHelp = `
+service [?]
+Update Service
+Examples:
+
+    Update a service
+    $ steam update service \
+        --service-id=? \
+        --service-name=?
+
+`
+
+func updateService(c *context) *cobra.Command {
+	var serviceId int64    // No description available
+	var serviceName string // No description available
+
+	cmd := newCmd(c, updateServiceHelp, func(c *context, args []string) {
+
+		// Update a service
+		err := c.remote.UpdateService(
+			serviceId,   // No description available
+			serviceName, // No description available
+		)
+		if err != nil {
+			log.Fatalln(err)
+		}
+		return
+	})
+
+	cmd.Flags().Int64Var(&serviceId, "service-id", serviceId, "No description available")
+	cmd.Flags().StringVar(&serviceName, "service-name", serviceName, "No description available")
 	return cmd
 }
 

--- a/gui/src/Proxy/CLI.ts
+++ b/gui/src/Proxy/CLI.ts
@@ -239,6 +239,11 @@ export function importModelFromCluster(clusterId: number, projectId: number, mod
   Proxy.Call("ImportModelFromCluster", req, print);
 }
 
+export function updateModel(modelId: number, modelName: string): void {
+  const req: any = { model_id: modelId, model_name: modelName };
+  Proxy.Call("UpdateModel", req, print);
+}
+
 export function deleteModel(modelId: number): void {
   const req: any = { model_id: modelId };
   Proxy.Call("DeleteModel", req, print);
@@ -302,6 +307,11 @@ export function getServicesForProject(projectId: number, offset: number, limit: 
 export function getServicesForModel(modelId: number, offset: number, limit: number): void {
   const req: any = { model_id: modelId, offset: offset, limit: limit };
   Proxy.Call("GetServicesForModel", req, print);
+}
+
+export function updateService(serviceId: number, serviceName: string): void {
+  const req: any = { service_id: serviceId, service_name: serviceName };
+  Proxy.Call("UpdateService", req, print);
 }
 
 export function deleteService(serviceId: number): void {

--- a/gui/src/Proxy/Proxy.ts
+++ b/gui/src/Proxy/Proxy.ts
@@ -573,6 +573,9 @@ export interface Service {
   // Import models from a cluster
   importModelFromCluster: (clusterId: number, projectId: number, modelKey: string, modelName: string, go: (error: Error, modelId: number) => void) => void
   
+  // Update a model
+  updateModel: (modelId: number, modelName: string, go: (error: Error) => void) => void
+  
   // Delete a model
   deleteModel: (modelId: number, go: (error: Error) => void) => void
   
@@ -611,6 +614,9 @@ export interface Service {
   
   // List services for a model
   getServicesForModel: (modelId: number, offset: number, limit: number, go: (error: Error, services: ScoringService[]) => void) => void
+  
+  // Update a service
+  updateService: (serviceId: number, serviceName: string, go: (error: Error) => void) => void
   
   // Delete a service
   deleteService: (serviceId: number, go: (error: Error) => void) => void
@@ -1386,6 +1392,18 @@ interface ImportModelFromClusterOut {
   
 }
 
+interface UpdateModelIn {
+  
+  model_id: number
+  
+  model_name: string
+  
+}
+
+interface UpdateModelOut {
+  
+}
+
 interface DeleteModelIn {
   
   model_id: number
@@ -1553,6 +1571,18 @@ interface GetServicesForModelIn {
 interface GetServicesForModelOut {
   
   services: ScoringService[]
+  
+}
+
+interface UpdateServiceIn {
+  
+  service_id: number
+  
+  service_name: string
+  
+}
+
+interface UpdateServiceOut {
   
 }
 
@@ -2745,6 +2775,18 @@ export function importModelFromCluster(clusterId: number, projectId: number, mod
   });
 }
 
+export function updateModel(modelId: number, modelName: string, go: (error: Error) => void): void {
+  const req: UpdateModelIn = { model_id: modelId, model_name: modelName };
+  Proxy.Call("UpdateModel", req, function(error, data) {
+    if (error) {
+      return go(error);
+    } else {
+      const d: UpdateModelOut = <UpdateModelOut> data;
+      return go(null);
+    }
+  });
+}
+
 export function deleteModel(modelId: number, go: (error: Error) => void): void {
   const req: DeleteModelIn = { model_id: modelId };
   Proxy.Call("DeleteModel", req, function(error, data) {
@@ -2897,6 +2939,18 @@ export function getServicesForModel(modelId: number, offset: number, limit: numb
     } else {
       const d: GetServicesForModelOut = <GetServicesForModelOut> data;
       return go(null, d.services);
+    }
+  });
+}
+
+export function updateService(serviceId: number, serviceName: string, go: (error: Error) => void): void {
+  const req: UpdateServiceIn = { service_id: serviceId, service_name: serviceName };
+  Proxy.Call("UpdateService", req, function(error, data) {
+    if (error) {
+      return go(error);
+    } else {
+      const d: UpdateServiceOut = <UpdateServiceOut> data;
+      return go(null);
     }
   });
 }

--- a/master/web/model_test.go
+++ b/master/web/model_test.go
@@ -14,7 +14,9 @@ func TestModelCRUD(tt *testing.T) {
 	clusterId, err := t.svc.RegisterCluster(t.su, ClusterAddress)
 	t.nil(err)
 
+	//
 	// -- C --
+	//
 
 	modelId := make([]int64, len(h2oModels))
 	for i, model := range h2oModels {
@@ -24,7 +26,9 @@ func TestModelCRUD(tt *testing.T) {
 		t.nil(err)
 	}
 
+	//
 	// -- R --
+	//
 
 	// model, err := t.svc.GetModel(t.su, modelId)
 	// t.nil(err)
@@ -47,29 +51,31 @@ func TestModelCRUD(tt *testing.T) {
 	t.nil(err)
 	t.log(binModels)
 
-	// binModel, err := t.svc.GetModelBinomial(t.su, binModelId)
-	// t.nil(err)
-	// t.log(binModel)
-
 	mulModels, err := t.svc.FindModelsMultinomial(t.su, projectId, "", "", true, 0, 1000)
 	t.nil(err)
 	t.log(mulModels)
-
-	// mulModel, err := t.svc.GetModelMultinomial(t.su, mulModelId)
-	// t.nil(err)
-	// t.log(mulModel)
 
 	regModels, err := t.svc.FindModelsRegression(t.su, projectId, "", "", true, 0, 1000)
 	t.nil(err)
 	t.log(regModels)
 
-	// regModel, err := t.svc.GetModelRegression(t.su, regModelId)
-	// t.nil(err)
-	// t.log(regModel)
-
+	//
 	// -- U --
+	//
 
+	updatedName := "NewName"
+
+	err = t.svc.UpdateModel(t.su, models[0].Id, updatedName)
+	t.nil(err)
+	model, err := t.svc.GetModel(t.su, models[0].Id)
+	t.nil(err)
+
+	t.ok(model.Name == updatedName, "Updated model name")
+
+	//
 	// -- D --
+	//
+
 	for _, id := range modelId {
 		err := t.svc.DeleteModel(t.su, id)
 		t.nil(err)

--- a/master/web/service.go
+++ b/master/web/service.go
@@ -1198,6 +1198,21 @@ func (s *Service) createMetricsTable(pz az.Principal, modelId int64, metrics *bi
 	return nil
 }
 
+func (s *Service) UpdateModel(pz az.Principal, modelId int64, modelName string) error {
+	if err := pz.CheckPermission(s.ds.Permissions.ManageModel); err != nil {
+		return err
+	}
+
+	// Update Model Name
+	if modelName != "" {
+		if err := s.ds.UpdateModelName(pz, modelId, modelName); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (s *Service) DeleteModel(pz az.Principal, modelId int64) error {
 	if err := pz.CheckPermission(s.ds.Permissions.ManageModel); err != nil {
 		return err
@@ -1510,6 +1525,21 @@ func (s *Service) GetServicesForModel(pz az.Principal, modelId, offset, limit in
 	}
 
 	return ss, nil
+}
+
+func (s *Service) UpdateService(pz az.Principal, serviceId int64, serviceName string) error {
+	if err := pz.CheckPermission(s.ds.Permissions.ManageService); err != nil {
+		return err
+	}
+
+	// Update Service Name
+	if serviceName != "" {
+		if err := s.ds.UpdateServiceName(pz, serviceId, serviceName); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (s *Service) DeleteService(pz az.Principal, serviceId int64) error {

--- a/master/web/service.go
+++ b/master/web/service.go
@@ -1210,7 +1210,7 @@ func (s *Service) UpdateModel(pz az.Principal, modelId int64, modelName string) 
 		}
 	}
 
-	return nil
+	return fmt.Errorf("No update specified")
 }
 
 func (s *Service) DeleteModel(pz az.Principal, modelId int64) error {
@@ -1539,7 +1539,7 @@ func (s *Service) UpdateService(pz az.Principal, serviceId int64, serviceName st
 		}
 	}
 
-	return nil
+	return fmt.Errorf("No update specified")
 }
 
 func (s *Service) DeleteService(pz az.Principal, serviceId int64) error {

--- a/master/web/service_test.go
+++ b/master/web/service_test.go
@@ -7,7 +7,9 @@ func TestServiceCRUD(tt *testing.T) {
 
 	// var names [...]string{"service1","service2","service3","service4", "service5"}
 
+	//
 	// -- Setup --
+	//
 
 	projectId, err := t.svc.CreateProject(t.su, "project1", "test project", "")
 	t.nil(err)
@@ -16,7 +18,9 @@ func TestServiceCRUD(tt *testing.T) {
 	modelId, err := t.svc.ImportModelFromCluster(t.su, clusterId, projectId, h2oModels[0].name, "")
 	t.nil(err)
 
+	//
 	// -- C --
+	//
 
 	serviceId := make([]int64, 5)
 	for i := 0; i < 5; i++ {
@@ -27,7 +31,9 @@ func TestServiceCRUD(tt *testing.T) {
 		}
 	}
 
+	//
 	// -- R --
+	//
 
 	services, err := t.svc.GetServices(t.su, 0, 1000)
 	t.nil(err)
@@ -38,9 +44,23 @@ func TestServiceCRUD(tt *testing.T) {
 
 	t.log(service)
 
+	//
 	// -- U --
+	//
 
+	updatedName := "NewName"
+
+	err = t.svc.UpdateService(t.su, services[0].Id, updatedName)
+	t.nil(err)
+	service, err = t.svc.GetService(t.su, services[0].Id)
+	t.nil(err)
+
+	t.ok(service.Name == updatedName, "Updated model name")
+
+	//
 	// -- D --
+	//
+
 	for i := 0; i < 5; i++ {
 		err := t.svc.StopService(t.su, serviceId[i])
 		t.nil(err)

--- a/python/steam.py
+++ b/python/steam.py
@@ -882,6 +882,23 @@ class RPCClient:
 		response = self.connection.call("ImportModelFromCluster", request)
 		return response['model_id']
 	
+	def update_model(self, model_id, model_name):
+		"""
+		Update a model
+
+		Parameters:
+		model_id: No description available (int64)
+		model_name: No description available (string)
+
+		Returns:None
+		"""
+		request = {
+			'model_id': model_id
+			'model_name': model_name
+		}
+		response = self.connection.call("UpdateModel", request)
+		return 
+	
 	def delete_model(self, model_id):
 		"""
 		Delete a model
@@ -1109,6 +1126,23 @@ class RPCClient:
 		}
 		response = self.connection.call("GetServicesForModel", request)
 		return response['services']
+	
+	def update_service(self, service_id, service_name):
+		"""
+		Update a service
+
+		Parameters:
+		service_id: No description available (int64)
+		service_name: No description available (string)
+
+		Returns:None
+		"""
+		request = {
+			'service_id': service_id
+			'service_name': service_name
+		}
+		response = self.connection.call("UpdateService", request)
+		return 
 	
 	def delete_service(self, service_id):
 		"""

--- a/srv/web/api/api.go
+++ b/srv/web/api/api.go
@@ -289,6 +289,7 @@ type Service struct {
 	FindModelsRegression          FindModelsRegression          `help:"List regression models"`
 	GetModelRegression            GetModelRegression            `help:"View a binomial model"`
 	ImportModelFromCluster        ImportModelFromCluster        `help:"Import models from a cluster"`
+	UpdateModel                   UpdateModel                   `help:"Update a model"`
 	DeleteModel                   DeleteModel                   `help:"Delete a model"`
 	CreateLabel                   CreateLabel                   `help:"Create a label"`
 	UpdateLabel                   UpdateLabel                   `help:"Update a label"`
@@ -302,6 +303,7 @@ type Service struct {
 	GetServices                   GetServices                   `help:"List all services"`
 	GetServicesForProject         GetServicesForProject         `help:"List services for a project"`
 	GetServicesForModel           GetServicesForModel           `help:"List services for a model"`
+	UpdateService                 UpdateService                 `help:"Update a service"`
 	DeleteService                 DeleteService                 `help:"Delete a service"`
 	AddEngine                     AddEngine                     `help:"Add an engine"`
 	GetEngine                     GetEngine                     `help:"Get engine details"`
@@ -616,6 +618,10 @@ type ImportModelFromCluster struct {
 	_         int
 	ModelId   int64
 }
+type UpdateModel struct {
+	ModelId   int64
+	ModelName string
+}
 type DeleteModel struct {
 	ModelId int64
 }
@@ -681,6 +687,10 @@ type GetServicesForModel struct {
 	Limit    int64
 	_        int
 	Services []ScoringService
+}
+type UpdateService struct {
+	ServiceId   int64
+	ServiceName string
 }
 type DeleteService struct {
 	ServiceId int64


### PR DESCRIPTION
Added API calls to allow name changes for models and services, and corresponding tests:

New APIs:
- UpdateModel(modelId _int64_, modelName _string_)
- UpdateService(serviceId _int64_, serviceName _string_)

Both of these will only change the name if a non-empty string is supplied
