### PR TITLE
STEAM-578: Add support Deep Water in Steam

### DIFF
--- a/lib/fs/fs.go
+++ b/lib/fs/fs.go
@@ -306,6 +306,10 @@ func GetGenModelPath(wd string, modelId int64) string {
 	return path.Join(GetModelPath(wd, modelId), "h2o-genmodel.jar")
 }
 
+func GetDeepwaterDepPath(wd string, modelId int64) string {
+	return path.Join(GetModelPath(wd, modelId), "deepwater-all.jar")
+}
+
 func GetAssetsPath(wd, asset string) string {
 	return path.Join(wd, AssetsDir, asset)
 }

--- a/master/download.go
+++ b/master/download.go
@@ -197,8 +197,9 @@ func (s *DownloadHandler) serveModel(w http.ResponseWriter, r *http.Request, pz 
 				projectId,
 				modelId,
 				model.LogicalName,
-				compiler.ArtifactWar,
 				"pojo",
+				model.Algorithm,
+				compiler.ArtifactWar,
 				"",
 			)
 			if err != nil {
@@ -214,8 +215,9 @@ func (s *DownloadHandler) serveModel(w http.ResponseWriter, r *http.Request, pz 
 				projectId,
 				modelId,
 				model.LogicalName,
-				compiler.ArtifactWar,
 				"mojo",
+				model.Algorithm,
+				compiler.ArtifactWar,
 				"",
 			)
 			if err != nil {
@@ -235,8 +237,9 @@ func (s *DownloadHandler) serveModel(w http.ResponseWriter, r *http.Request, pz 
 				projectId,
 				modelId,
 				model.LogicalName,
-				compiler.ArtifactPythonWar,
 				"pojo",
+				model.Algorithm,
+				compiler.ArtifactPythonWar,
 				packageName,
 			)
 			if err != nil {
@@ -257,8 +260,9 @@ func (s *DownloadHandler) serveModel(w http.ResponseWriter, r *http.Request, pz 
 				projectId,
 				modelId,
 				model.LogicalName,
-				compiler.ArtifactPythonWar,
 				"mojo",
+				model.Algorithm,
+				compiler.ArtifactPythonWar,
 				packageName,
 			)
 			if err != nil {
@@ -273,8 +277,9 @@ func (s *DownloadHandler) serveModel(w http.ResponseWriter, r *http.Request, pz 
 				projectId,
 				modelId,
 				model.LogicalName,
-				compiler.ArtifactJar,
 				"pojo",
+				model.Algorithm,
+				compiler.ArtifactJar,
 				"",
 			)
 			if err != nil {

--- a/master/web/service.go
+++ b/master/web/service.go
@@ -1252,7 +1252,7 @@ func (s *Service) createMetricsTable(pz az.Principal, modelId int64, metrics *bi
 
 func (s *Service) CheckMojo(pz az.Principal, algo string) (bool, error) {
 	switch algo {
-	case "Gradient Boosting Method", "Distributed Random Forest":
+	case "Gradient Boosting Method", "Distributed Random Forest", "Deep Water":
 		return true, nil
 	}
 	return false, nil
@@ -1318,6 +1318,13 @@ func (s *Service) ImportModelMojo(pz az.Principal, modelId int64) error {
 	}
 	if _, err := h2o.ExportGenModel(modelPath); err != nil {
 		return errors.Wrap(err, "failed to export java dependency")
+	}
+
+	// MOJO only check
+	if m.Algorithm == "Deep Water" {
+		if _, err := h2o.ExportDeepWaterAll(modelPath); err != nil {
+			return errors.Wrap(err, "exporting Deep Water dependency")
+		}
 	}
 
 	if !m.LogicalName.Valid {
@@ -1510,8 +1517,9 @@ func (s *Service) StartService(pz az.Principal, modelId int64, name, packageName
 		model.ProjectId,
 		model.Id,
 		model.LogicalName.String,
-		artifact,
 		model.ModelObjectType.String,
+		model.Algorithm,
+		artifact,
 		packageName,
 	)
 	if err != nil {

--- a/srv/compiler/deepwater.go
+++ b/srv/compiler/deepwater.go
@@ -1,0 +1,51 @@
+/*
+  Copyright (C) 2016 H2O.ai, Inc. <http://h2o.ai/>
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as
+  published by the Free Software Foundation, either version 3 of the
+  License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU Affero General Public License for more details.
+
+  You should have received a copy of the GNU Affero General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+package compiler
+
+import (
+	"mime/multipart"
+
+	"github.com/h2oai/steam/lib/fs"
+	"github.com/pkg/errors"
+)
+
+const fileTypeDWDep = "deepwater"
+
+type Deepwater struct {
+	*Model
+
+	deepwaterDep string
+}
+
+// NewDeepWater returns a new instance of Deepwater.
+func NewDeepwater(workingDirectory string, modelId int64, logicalName, modelType string, pythonFiles ...string) *Deepwater {
+	return &Deepwater{
+		Model:        NewModel(workingDirectory, modelId, logicalName, modelType, pythonFiles...),
+		deepwaterDep: fs.GetDeepwaterDepPath(workingDirectory, modelId),
+	}
+}
+
+func (c *Deepwater) AttachFiles(w *multipart.Writer) error {
+	if err := c.Model.AttachFiles(w); err != nil {
+		return err
+	}
+
+	return errors.Wrap(
+		attachFile(w, c.deepwaterDep, fileTypeDWDep),
+		"attaching deepwater dependency",
+	)
+}

--- a/srv/compiler/model.go
+++ b/srv/compiler/model.go
@@ -1,0 +1,81 @@
+/*
+  Copyright (C) 2016 H2O.ai, Inc. <http://h2o.ai/>
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as
+  published by the Free Software Foundation, either version 3 of the
+  License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU Affero General Public License for more details.
+
+  You should have received a copy of the GNU Affero General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+package compiler
+
+import (
+	"fmt"
+	"mime/multipart"
+
+	"github.com/h2oai/steam/lib/fs"
+	"github.com/pkg/errors"
+)
+
+type Model struct {
+	modelPath string
+	modelType string
+	javaDep   string
+
+	pythonFilePaths []string
+}
+
+func NewModel(workingDirectory string, modelId int64, logicalName, modelType string, pythonFiles ...string) *Model {
+	m := &Model{javaDep: fs.GetGenModelPath(workingDirectory, modelId)}
+
+	switch modelType {
+	case "pojo":
+		m.modelPath = fs.GetJavaModelPath(workingDirectory, modelId, logicalName)
+		m.modelType = fileTypeJava
+	case "mojo":
+		m.modelPath = fs.GetMOJOPath(workingDirectory, modelId, logicalName)
+		m.modelType = fileTypeMOJO
+	case "":
+		panic("model type unset")
+	default:
+		panic(fmt.Errorf("invalid model type %q", modelType))
+	}
+
+	pythonPaths := make([]string, len(pythonFiles))
+	for i, path := range pythonFiles {
+		pythonPaths[i] = path
+	}
+	m.pythonFilePaths = pythonPaths
+
+	return m
+}
+
+func (c *Model) AttachFiles(w *multipart.Writer) error {
+	if err := attachFile(w, c.modelPath, c.modelType); err != nil {
+		return errors.Wrap(err, "attaching model")
+	}
+	if err := attachFile(w, c.javaDep, fileTypeJavaDep); err != nil {
+		return errors.Wrap(err, "attaching java dependency")
+	}
+
+	for i, file := range c.pythonFilePaths {
+		if i < 1 {
+			if err := attachFile(w, file, fileTypePythonMain); err != nil {
+				return errors.Wrap(err, "attaching Python main file")
+			}
+		} else {
+			if err := attachFile(w, file, fileTypePythonOther); err != nil {
+				return errors.Wrap(err, "attaching Python file")
+			}
+		}
+	}
+
+	return nil
+}

--- a/srv/h2ov3/service.go
+++ b/srv/h2ov3/service.go
@@ -206,6 +206,13 @@ func (h *H2O) ExportMOJO(modelID, p string) (string, error) {
 	return f, nil
 }
 
+// FIXME: MUST BE H2O VERSION WITH DEEPWATER
+func (h *H2O) ExportDeepWaterAll(p string) (string, error) {
+	f, err := h.download("/3/deepwater-all.jar", path.Join(p, "deepwater-all.jar"), false)
+
+	return f, errors.Wrap(err, "downloading Deepwater depencency")
+}
+
 // func (h *H2O) CompilePojo(javaModel, jar string) error {
 // 	if _, err := h.post("/compile", url.Values{
 // 		"pojo": {javaModel},


### PR DESCRIPTION
No new API's. 

Modified internal calls to `StartService`. Now Creates a `ModelAsset` which satisfies `AttachModel(w *multipart.Writer) (error)`. AttachModel should attach Prediction Service Builder's necessary dependencies to the buffer.