### PR TITLE
PUBSTEAM-17: Allow prediction service address to display external

### DIFF
--- a/lib/svc/svc.go
+++ b/lib/svc/svc.go
@@ -54,13 +54,9 @@ func svcScan(r io.Reader, name, username string, err *string, pass chan struct{}
 }
 
 // Start starts a scoring service.
-func Start(warfile, jetty, host string, port int, name, username string) (int, error) {
+func Start(warfile, jetty string, port int, name, username string) (int, error) {
 
 	argv := []string{"-jar", jetty, "--port", strconv.Itoa(port)}
-
-	if len(host) > 0 {
-		argv = append(argv, "--host", host)
-	}
 
 	argv = append(argv, warfile)
 

--- a/master/web/service.go
+++ b/master/web/service.go
@@ -1534,7 +1534,6 @@ func (s *Service) StartService(pz az.Principal, modelId int64, name, packageName
 	pid, err := svc.Start(
 		warFilePath,
 		fs.GetAssetsPath(s.workingDir, "jetty-runner.jar"),
-		s.scoringServiceAddress,
 		port,
 		name,
 		pz.Name(),


### PR DESCRIPTION
Dropping host, lets us change the value of the reported address for
scoring services as a start up flag.