### PR TITLE
STEAM-549: Clean up unused and deprecated start flags

### DIFF
--- a/master/main.go
+++ b/master/main.go
@@ -38,14 +38,14 @@ import (
 )
 
 const (
-	defaultWebAddress                = ":9000"
-	defaultClusterProxyAddress       = ":9001"
-	defaultCompilationAddress        = ":8080"
-	defaultScoringServiceHost        = ""
-	DefaultScoringServicePortsString = "1025:65535"
+	defaultWebAddress                   = ":9000"
+	defaultClusterProxyAddress          = ":9001"
+	defaultCompilationAddress           = ":8080"
+	defaultPredictionServiceHost        = ""
+	DefaultPredictionServicePortsString = "1025:65535"
 )
 
-var defaultScoringServicePorts = [...]int{1025, 65535}
+var defaultPredictionServicePorts = [...]int{1025, 65535}
 
 type DBOpts struct {
 	Connection        data.Connection
@@ -55,8 +55,6 @@ type DBOpts struct {
 
 type YarnOpts struct {
 	KerberosEnabled bool
-	Username        string
-	Keytab          string
 }
 
 type Opts struct {
@@ -68,8 +66,8 @@ type Opts struct {
 	WorkingDirectory          string
 	ClusterProxyAddress       string
 	CompilationServiceAddress string
-	ScoringServiceHost        string
-	ScoringServicePorts       [2]int
+	PredictionServiceHost     string
+	PredictionServicePorts    [2]int
 	EnableProfiler            bool
 	Yarn                      YarnOpts
 	DB                        DBOpts
@@ -97,10 +95,10 @@ var DefaultOpts = &Opts{
 	path.Join(".", fs.VarDir, "master"),
 	defaultClusterProxyAddress,
 	defaultCompilationAddress,
-	defaultScoringServiceHost,
-	defaultScoringServicePorts,
+	defaultPredictionServiceHost,
+	defaultPredictionServicePorts,
 	false,
-	YarnOpts{false, "", ""},
+	YarnOpts{false},
 	DBOpts{DefaultConnection, "", ""},
 }
 
@@ -160,14 +158,14 @@ func Run(version, buildDate string, opts Opts) {
 		authProvider = newBasicAuthProvider(defaultAz, webAddress)
 	}
 
-	// --- set up scoring service launch host
+	// --- set up prediction service launch host
 
-	var scoringServiceHost string
-	if opts.ScoringServiceHost != "" {
-		scoringServiceHost = opts.ScoringServiceHost
+	var predictionServiceHost string
+	if opts.PredictionServiceHost != "" {
+		predictionServiceHost = opts.PredictionServiceHost
 	} else {
 		var err error
-		scoringServiceHost, err = fs.GetExternalHost()
+		predictionServiceHost, err = fs.GetExternalHost()
 		if err != nil {
 			log.Fatalln(err)
 		}
@@ -180,12 +178,10 @@ func Run(version, buildDate string, opts Opts) {
 		wd,
 		ds,
 		opts.CompilationServiceAddress,
-		scoringServiceHost,
+		predictionServiceHost,
 		opts.ClusterProxyAddress,
-		opts.ScoringServicePorts,
+		opts.PredictionServicePorts,
 		opts.Yarn.KerberosEnabled,
-		opts.Yarn.Username,
-		opts.Yarn.Keytab,
 	)
 	webServiceImpl := &srvweb.Impl{webService, defaultAz}
 

--- a/master/web/driver.go
+++ b/master/web/driver.go
@@ -44,8 +44,6 @@ type driverDBOpts struct {
 
 type driverYarnOpts struct {
 	KerberosEnabled bool
-	Username        string
-	Keytab          string
 }
 
 func newService(opts driverOpts) (web.Service, az.Directory, error) {
@@ -72,7 +70,5 @@ func newService(opts driverOpts) (web.Service, az.Directory, error) {
 		opts.ClusterProxyAddress,
 		opts.ScoringServicePorts,
 		opts.Yarn.KerberosEnabled,
-		opts.Yarn.Username,
-		opts.Yarn.Keytab,
 	), ds, nil
 }

--- a/master/web/service.go
+++ b/master/web/service.go
@@ -52,8 +52,6 @@ type Service struct {
 	scoringServicePortMin     int
 	scoringServicePortMax     int
 	kerberosEnabled           bool
-	username                  string
-	keytab                    string
 }
 
 func NewService(
@@ -62,7 +60,6 @@ func NewService(
 	compilationServiceAddress, scoringServiceAddress, clusterProxyAddress string,
 	scoringServicePortsRange [2]int,
 	kerberos bool,
-	username, keytab string,
 ) *Service {
 	return &Service{
 		workingDir,
@@ -70,7 +67,6 @@ func NewService(
 		compilationServiceAddress, scoringServiceAddress, clusterProxyAddress,
 		scoringServicePortsRange[0], scoringServicePortsRange[1],
 		kerberos,
-		username, keytab,
 	}
 }
 

--- a/master/web/setup_test.go
+++ b/master/web/setup_test.go
@@ -106,7 +106,7 @@ func newTest(t *testing.T) *test {
 		compilationServiceAddress,
 		"",
 		[2]int{1025, 65535},
-		driverYarnOpts{false, "", ""},
+		driverYarnOpts{false},
 		dbOpts,
 	}
 	svc, dir, err := newService(opts)


### PR DESCRIPTION
Remove all DB flags and unused yarn flags. Add deprecated flags for
scoring service -> prediction service