### PR TITLE
Proxy support

### DIFF
--- a/cli/start_cluster.go
+++ b/cli/start_cluster.go
@@ -39,6 +39,7 @@ func startCluster(c *context) *cobra.Command {
 	var (
 		size   int
 		memory string
+		secure bool
 	)
 
 	cmd := newCmd(c, startClusterHelp, func(c *context, args []string) {
@@ -55,7 +56,7 @@ func startCluster(c *context) *cobra.Command {
 		// --- add additional args here ---
 
 		log.Println("Attempting to start cluster...")
-		clusterId, err := c.remote.StartYarnCluster(clusterName, engineId, size, memory, "")
+		clusterId, err := c.remote.StartYarnCluster(clusterName, engineId, size, memory, secure, "")
 		if err != nil {
 			log.Fatalln(err)
 		}

--- a/cli2/cli.go
+++ b/cli2/cli.go
@@ -3976,6 +3976,7 @@ func startCluster(c *context) *cobra.Command {
 	var engineId int64     // No description available
 	var keytab string      // No description available
 	var memory string      // No description available
+	var secure bool        // No description available
 	var size int           // No description available
 
 	cmd := newCmd(c, startClusterHelp, func(c *context, args []string) {
@@ -3987,6 +3988,7 @@ func startCluster(c *context) *cobra.Command {
 				engineId,    // No description available
 				size,        // No description available
 				memory,      // No description available
+				secure,      // No description available
 				keytab,      // No description available
 			)
 			if err != nil {
@@ -4002,6 +4004,7 @@ func startCluster(c *context) *cobra.Command {
 	cmd.Flags().Int64Var(&engineId, "engine-id", engineId, "No description available")
 	cmd.Flags().StringVar(&keytab, "keytab", keytab, "No description available")
 	cmd.Flags().StringVar(&memory, "memory", memory, "No description available")
+	cmd.Flags().BoolVar(&secure, "secure", secure, "No description available")
 	cmd.Flags().IntVar(&size, "size", size, "No description available")
 	return cmd
 }

--- a/gui/src/Clusters/Clusters.tsx
+++ b/gui/src/Clusters/Clusters.tsx
@@ -72,7 +72,7 @@ export class Clusters extends React.Component<Props & DispatchProps, any> {
 
   goProxy(cluster) {
     document.cookie = cluster.name + "=" + cluster.token;
-    let url = "http://" + window.location.hostname + ":9999/" + cluster.name + "/";
+    let url = "http://" + window.location.hostname + ":9999" + cluster.context_path;
     window.open(url, "_blank");
   }
 
@@ -164,7 +164,7 @@ export class Clusters extends React.Component<Props & DispatchProps, any> {
             return (
               <Panel key={i}>
                 <header>
-                  <span><i className="fa fa-cubes mar-bot-20"/> <a href={'http://' + cluster.address + '/' + cluster.name + '/'} target="_blank"
+                  <span><i className="fa fa-cubes mar-bot-20"/> <a href={'http://' + cluster.address + cluster.context_path} target="_blank"
                                                         rel="noopener" className="charcoal-grey semibold">{cluster.name}</a> -- {cluster.status.total_cpu_count}&nbsp;cores</span>
                   <span className="remove-cluster">
                     <button className="remove-cluster-button test" onClick={this.goProxy.bind(this, cluster)}>

--- a/gui/src/Clusters/Clusters.tsx
+++ b/gui/src/Clusters/Clusters.tsx
@@ -71,7 +71,7 @@ export class Clusters extends React.Component<Props & DispatchProps, any> {
   }
 
   goProxy(cluster) {
-    document.cookie = cluster.name + "=" + cluster.token
+    document.cookie = cluster.name + "=" + cluster.token;
     let url = "http://" + window.location.hostname + ":9999/" + cluster.name + "/";
     window.open(url, "_blank");
   }

--- a/gui/src/Clusters/Clusters.tsx
+++ b/gui/src/Clusters/Clusters.tsx
@@ -72,7 +72,7 @@ export class Clusters extends React.Component<Props & DispatchProps, any> {
 
   goProxy(cluster) {
     document.cookie = cluster.name + "=" + cluster.token;
-    let url = "http://" + window.location.hostname + ":9999" + cluster.context_path + "/flow/index.html";
+    let url = "http://" + window.location.hostname + ":9999" + cluster.context_path + "flow/index.html";
     window.open(url, "_blank");
   }
 
@@ -166,11 +166,14 @@ export class Clusters extends React.Component<Props & DispatchProps, any> {
                 <header>
                   <span><i className="fa fa-cubes mar-bot-20"/> <a href={'http://' + cluster.address + cluster.context_path} target="_blank"
                                                         rel="noopener" className="charcoal-grey semibold">{cluster.name}</a> -- {cluster.status.total_cpu_count}&nbsp;cores</span>
-                  <span className="remove-cluster">
-                    <button className="remove-cluster-button test" onClick={this.goProxy.bind(this, cluster)}>
-                      <i className="fa fa-arrow-circle-o-right no-margin"/>
-                    </button>
-                  </span>
+                  { cluster.context_path != "/" ?
+                    <span className="remove-cluster">
+                      <button className="remove-cluster-button test" onClick={this.goProxy.bind(this, cluster)}>
+                        <i className="fa fa-arrow-circle-o-right no-margin"/>
+                      </button>
+                    </span>
+                    : null
+                  }
                   <span className="remove-cluster">
                     {_.get(this.props.config, 'kerberos_enabled', false) ? <input ref="keytabFilename" type="text" placeholder="Keytab filename"/> : null}
                     <button className="remove-cluster-button" onClick={(e) => this.onDeleteClusterClicked(cluster)}><i

--- a/gui/src/Clusters/Clusters.tsx
+++ b/gui/src/Clusters/Clusters.tsx
@@ -70,6 +70,12 @@ export class Clusters extends React.Component<Props & DispatchProps, any> {
     this.props.getConfig();
   }
 
+  goProxy(cluster) {
+    document.cookie = cluster.name + "=" + cluster.token
+    let url = "http://" + window.location.hostname + ":9999/" + cluster.name + "/";
+    window.open(url, "_blank");
+  }
+
   openYarnClusterModal() {
     this.setState({
       yarnClusterModalOpen: true
@@ -158,11 +164,15 @@ export class Clusters extends React.Component<Props & DispatchProps, any> {
             return (
               <Panel key={i}>
                 <header>
-                  <span><i className="fa fa-cubes mar-bot-20"/> <a href={'http://' + cluster.address} target="_blank"
+                  <span><i className="fa fa-cubes mar-bot-20"/> <a href={'http://' + cluster.address + '/' + cluster.name + '/'} target="_blank"
                                                         rel="noopener" className="charcoal-grey semibold">{cluster.name}</a> -- {cluster.status.total_cpu_count}&nbsp;cores</span>
                   <span className="remove-cluster">
+                    <button className="remove-cluster-button test" onClick={this.goProxy.bind(this, cluster)}>
+                      <i className="fa fa-arrow-circle-o-right no-margin"/>
+                    </button>
+                  </span>
+                  <span className="remove-cluster">
                     {_.get(this.props.config, 'kerberos_enabled', false) ? <input ref="keytabFilename" type="text" placeholder="Keytab filename"/> : null}
-
                     <button className="remove-cluster-button" onClick={(e) => this.onDeleteClusterClicked(cluster)}><i
                       className="fa fa-trash no-margin"/></button>
                   </span>

--- a/gui/src/Clusters/Clusters.tsx
+++ b/gui/src/Clusters/Clusters.tsx
@@ -72,7 +72,7 @@ export class Clusters extends React.Component<Props & DispatchProps, any> {
 
   goProxy(cluster) {
     document.cookie = cluster.name + "=" + cluster.token;
-    let url = "http://" + window.location.hostname + ":9999" + cluster.context_path;
+    let url = "http://" + window.location.hostname + ":9999" + cluster.context_path + "/flow/index.html";
     window.open(url, "_blank");
   }
 

--- a/gui/src/Clusters/actions/clusters.actions.ts
+++ b/gui/src/Clusters/actions/clusters.actions.ts
@@ -108,14 +108,14 @@ export function uploadEngine(file) {
   };
 }
 
-export function startYarnCluster(clusterName, engineId, size, memory, keytab) {
+export function startYarnCluster(clusterName, engineId, size, memory, secure, keytab) {
   if (!clusterName || !engineId || !size || !memory) {
     openNotification(NotificationType.Error, "Error", 'All fields are required', null);
   }
   return (dispatch) => {
     dispatch(startCluster());
     dispatch(openNotification(NotificationType.Info, "Update", 'Connecting to YARN...', null));
-    Remote.startClusterOnYarn(clusterName, engineId, size, memory, keytab, (error, clusterId) => {
+    Remote.startClusterOnYarn(clusterName, engineId, size, memory, secure, keytab, (error, clusterId) => {
       if (error) {
         dispatch(openNotification(NotificationType.Error, "Error", error.toString(), null));
         dispatch(startClusterCompleted(error.toString()));

--- a/gui/src/Clusters/components/LaunchCluster.tsx
+++ b/gui/src/Clusters/components/LaunchCluster.tsx
@@ -72,7 +72,6 @@ export class LaunchCluster extends React.Component<Props & DispatchProps, any> {
     let keytab = _.get((this.refs.clusterForm.querySelector('input[name="keytab"]') as HTMLInputElement), 'value', '');
     let secure = (this.refs.clusterForm.querySelector('input[name="secure"]') as HTMLInputElement).checked;
 
-    this.props.startYarnCluster(clusterName, parseInt(engineId, 10), parseInt(size, 10), memory + 'g', keytab);
     this.props.startYarnCluster(clusterName, parseInt(engineId, 10), parseInt(size, 10), memory + 'g', secure, keytab);
   }
 

--- a/gui/src/Clusters/components/LaunchCluster.tsx
+++ b/gui/src/Clusters/components/LaunchCluster.tsx
@@ -70,7 +70,7 @@ export class LaunchCluster extends React.Component<Props & DispatchProps, any> {
     let size = (this.refs.clusterForm.querySelector('input[name="size"]') as HTMLInputElement).value;
     let memory = (this.refs.clusterForm.querySelector('input[name="memory"]') as HTMLInputElement).value;
     let keytab = _.get((this.refs.clusterForm.querySelector('input[name="keytab"]') as HTMLInputElement), 'value', '');
-    let secure = (this.refs.clusterForm.querySelector('input[name="secure"]') as HTMLInputElement).value === "on";
+    let secure = (this.refs.clusterForm.querySelector('input[name="secure"]') as HTMLInputElement).checked;
 
     this.props.startYarnCluster(clusterName, parseInt(engineId, 10), parseInt(size, 10), memory + 'g', keytab);
     this.props.startYarnCluster(clusterName, parseInt(engineId, 10), parseInt(size, 10), memory + 'g', secure, keytab);

--- a/gui/src/Clusters/components/LaunchCluster.tsx
+++ b/gui/src/Clusters/components/LaunchCluster.tsx
@@ -70,7 +70,10 @@ export class LaunchCluster extends React.Component<Props & DispatchProps, any> {
     let size = (this.refs.clusterForm.querySelector('input[name="size"]') as HTMLInputElement).value;
     let memory = (this.refs.clusterForm.querySelector('input[name="memory"]') as HTMLInputElement).value;
     let keytab = _.get((this.refs.clusterForm.querySelector('input[name="keytab"]') as HTMLInputElement), 'value', '');
+    let secure = (this.refs.clusterForm.querySelector('input[name="secure"]') as HTMLInputElement).value === "on";
+
     this.props.startYarnCluster(clusterName, parseInt(engineId, 10), parseInt(size, 10), memory + 'g', keytab);
+    this.props.startYarnCluster(clusterName, parseInt(engineId, 10), parseInt(size, 10), memory + 'g', secure, keytab);
   }
 
   uploadEngine(event) {
@@ -113,6 +116,16 @@ export class LaunchCluster extends React.Component<Props & DispatchProps, any> {
               </Cell>
               <Cell>
                 <NumericInput name="memory" min="1"/>GB
+              </Cell>
+            </Row>
+            <Row>
+              <Cell>
+                SECURE
+              </Cell>
+              <Cell>
+                <div className="checkbox">
+                  <input type="checkbox" name="secure" />
+                </div>
               </Cell>
             </Row>
             <Row>

--- a/gui/src/Proxy/CLI.ts
+++ b/gui/src/Proxy/CLI.ts
@@ -56,8 +56,8 @@ export function unregisterCluster(clusterId: number): void {
   Proxy.Call("UnregisterCluster", req, print);
 }
 
-export function startClusterOnYarn(clusterName: string, engineId: number, size: number, memory: string, keytab: string): void {
-  const req: any = { cluster_name: clusterName, engine_id: engineId, size: size, memory: memory, keytab: keytab };
+export function startClusterOnYarn(clusterName: string, engineId: number, size: number, memory: string, secure: boolean, keytab: string): void {
+  const req: any = { cluster_name: clusterName, engine_id: engineId, size: size, memory: memory, secure: secure, keytab: keytab };
   Proxy.Call("StartClusterOnYarn", req, print);
 }
 

--- a/gui/src/Proxy/Proxy.ts
+++ b/gui/src/Proxy/Proxy.ts
@@ -27,459 +27,459 @@
 import * as Proxy from './xhr';
 
 export interface BinomialModel {
-  
+
   id: number
-  
+
   training_dataset_id: number
-  
+
   validation_dataset_id: number
-  
+
   name: string
-  
+
   cluster_name: string
-  
+
   model_key: string
-  
+
   algorithm: string
-  
+
   model_category: string
-  
+
   dataset_name: string
-  
+
   response_column_name: string
-  
+
   logical_name: string
-  
+
   location: string
-  
+
   model_object_type: string
-  
+
   max_runtime: number
-  
+
   json_metrics: string
-  
+
   created_at: number
-  
+
   label_id: number
-  
+
   label_name: string
-  
+
   mse: number
-  
+
   r_squared: number
-  
+
   logloss: number
-  
+
   auc: number
-  
+
   gini: number
-  
+
 }
 
 export interface Cluster {
-  
+
   id: number
-  
+
   name: string
-  
+
   type_id: number
-  
+
   detail_id: number
-  
+
   address: string
-  
+
   state: string
-  
+
   created_at: number
-  
+
 }
 
 export interface ClusterStatus {
-  
+
   version: string
-  
+
   status: string
-  
+
   max_memory: string
-  
+
   total_cpu_count: number
-  
+
   total_allowed_cpu_count: number
-  
+
 }
 
 export interface ClusterType {
-  
+
   id: number
-  
+
   name: string
-  
+
 }
 
 export interface Config {
-  
+
   kerberos_enabled: boolean
-  
+
   cluster_proxy_address: string
-  
+
 }
 
 export interface Dataset {
-  
+
   id: number
-  
+
   datasource_id: number
-  
+
   name: string
-  
+
   description: string
-  
+
   frame_name: string
-  
+
   response_column_name: string
-  
+
   json_properties: string
-  
+
   created_at: number
-  
+
 }
 
 export interface Datasource {
-  
+
   id: number
-  
+
   project_id: number
-  
+
   name: string
-  
+
   description: string
-  
+
   kind: string
-  
+
   configuration: string
-  
+
   created_at: number
-  
+
 }
 
 export interface Engine {
-  
+
   id: number
-  
+
   name: string
-  
+
   location: string
-  
+
   created_at: number
-  
+
 }
 
 export interface EntityHistory {
-  
+
   identity_id: number
-  
+
   action: string
-  
+
   description: string
-  
+
   created_at: number
-  
+
 }
 
 export interface EntityPrivilege {
-  
+
   kind: string
-  
+
   workgroup_id: number
-  
+
   workgroup_name: string
-  
+
   workgroup_description: string
-  
+
 }
 
 export interface EntityType {
-  
+
   id: number
-  
+
   name: string
-  
+
 }
 
 export interface Identity {
-  
+
   id: number
-  
+
   name: string
-  
+
   is_active: boolean
-  
+
   last_login: number
-  
+
   created: number
-  
+
 }
 
 export interface Job {
-  
+
   name: string
-  
+
   cluster_name: string
-  
+
   description: string
-  
+
   progress: string
-  
+
   started_at: number
-  
+
   completed_at: number
-  
+
 }
 
 export interface Label {
-  
+
   id: number
-  
+
   project_id: number
-  
+
   model_id: number
-  
+
   name: string
-  
+
   description: string
-  
+
   created_at: number
-  
+
 }
 
 export interface Model {
-  
+
   id: number
-  
+
   training_dataset_id: number
-  
+
   validation_dataset_id: number
-  
+
   name: string
-  
+
   cluster_name: string
-  
+
   model_key: string
-  
+
   algorithm: string
-  
+
   model_category: string
-  
+
   dataset_name: string
-  
+
   response_column_name: string
-  
+
   logical_name: string
-  
+
   location: string
-  
+
   model_object_type: string
-  
+
   max_runtime: number
-  
+
   json_metrics: string
-  
+
   created_at: number
-  
+
   label_id: number
-  
+
   label_name: string
-  
+
 }
 
 export interface MultinomialModel {
-  
+
   id: number
-  
+
   training_dataset_id: number
-  
+
   validation_dataset_id: number
-  
+
   name: string
-  
+
   cluster_name: string
-  
+
   model_key: string
-  
+
   algorithm: string
-  
+
   model_category: string
-  
+
   dataset_name: string
-  
+
   response_column_name: string
-  
+
   logical_name: string
-  
+
   location: string
-  
+
   model_object_type: string
-  
+
   max_runtime: number
-  
+
   json_metrics: string
-  
+
   created_at: number
-  
+
   label_id: number
-  
+
   label_name: string
-  
+
   mse: number
-  
+
   r_squared: number
-  
+
   logloss: number
-  
+
 }
 
 export interface Permission {
-  
+
   id: number
-  
+
   code: string
-  
+
   description: string
-  
+
 }
 
 export interface Project {
-  
+
   id: number
-  
+
   name: string
-  
+
   description: string
-  
+
   model_category: string
-  
+
   created_at: number
-  
+
 }
 
 export interface RegressionModel {
-  
+
   id: number
-  
+
   training_dataset_id: number
-  
+
   validation_dataset_id: number
-  
+
   name: string
-  
+
   cluster_name: string
-  
+
   model_key: string
-  
+
   algorithm: string
-  
+
   model_category: string
-  
+
   dataset_name: string
-  
+
   response_column_name: string
-  
+
   logical_name: string
-  
+
   location: string
-  
+
   model_object_type: string
-  
+
   max_runtime: number
-  
+
   json_metrics: string
-  
+
   created_at: number
-  
+
   label_id: number
-  
+
   label_name: string
-  
+
   mse: number
-  
+
   r_squared: number
-  
+
   mean_residual_deviance: number
-  
+
 }
 
 export interface Role {
-  
+
   id: number
-  
+
   name: string
-  
+
   description: string
-  
+
   created: number
-  
+
 }
 
 export interface ScoringService {
-  
+
   id: number
-  
+
   model_id: number
-  
+
   name: string
-  
+
   address: string
-  
+
   port: number
-  
+
   process_id: number
-  
+
   state: string
-  
+
   created_at: number
-  
+
 }
 
 export interface UserRole {
-  
+
   kind: string
-  
+
   identity_id: number
-  
+
   identity_name: string
-  
+
   role_id: number
-  
+
   role_name: string
-  
+
 }
 
 export interface Workgroup {
-  
+
   id: number
-  
+
   name: string
-  
+
   description: string
-  
+
   created: number
-  
+
 }
 
 export interface YarnCluster {
-  
+
   id: number
-  
+
   engine_id: number
-  
+
   size: number
-  
+
   application_id: string
-  
+
   memory: string
-  
+
   username: string
-  
+
 }
 
 
@@ -487,1845 +487,1847 @@ export interface YarnCluster {
 
 
 export interface Service {
-  
+
   // Ping the Steam server
   pingServer: (input: string, go: (error: Error, output: string) => void) => void
-  
+
   // No description available
   getConfig: (go: (error: Error, config: Config) => void) => void
-  
+
   // Connect to a cluster
   registerCluster: (address: string, go: (error: Error, clusterId: number) => void) => void
-  
+
   // Disconnect from a cluster
   unregisterCluster: (clusterId: number, go: (error: Error) => void) => void
-  
+
   // Start a cluster using Yarn
-  startClusterOnYarn: (clusterName: string, engineId: number, size: number, memory: string, keytab: string, go: (error: Error, clusterId: number) => void) => void
-  
+  startClusterOnYarn: (clusterName: string, engineId: number, size: number, memory: string, secure: boolean, keytab: string, go: (error: Error, clusterId: number) => void) => void
+
   // Stop a cluster using Yarn
   stopClusterOnYarn: (clusterId: number, keytab: string, go: (error: Error) => void) => void
-  
+
   // Get cluster details
   getCluster: (clusterId: number, go: (error: Error, cluster: Cluster) => void) => void
-  
+
   // Get cluster details (Yarn only)
   getClusterOnYarn: (clusterId: number, go: (error: Error, cluster: YarnCluster) => void) => void
-  
+
   // List clusters
   getClusters: (offset: number, limit: number, go: (error: Error, clusters: Cluster[]) => void) => void
-  
+
   // Get cluster status
   getClusterStatus: (clusterId: number, go: (error: Error, clusterStatus: ClusterStatus) => void) => void
-  
+
   // Delete a cluster
   deleteCluster: (clusterId: number, go: (error: Error) => void) => void
-  
+
   // Get job details
   getJob: (clusterId: number, jobName: string, go: (error: Error, job: Job) => void) => void
-  
+
   // List jobs
   getJobs: (clusterId: number, go: (error: Error, jobs: Job[]) => void) => void
-  
+
   // Create a project
   createProject: (name: string, description: string, modelCategory: string, go: (error: Error, projectId: number) => void) => void
-  
+
   // List projects
   getProjects: (offset: number, limit: number, go: (error: Error, projects: Project[]) => void) => void
-  
+
   // Get project details
   getProject: (projectId: number, go: (error: Error, project: Project) => void) => void
-  
+
   // Delete a project
   deleteProject: (projectId: number, go: (error: Error) => void) => void
-  
+
   // Create a datasource
   createDatasource: (projectId: number, name: string, description: string, path: string, go: (error: Error, datasourceId: number) => void) => void
-  
+
   // List datasources
   getDatasources: (projectId: number, offset: number, limit: number, go: (error: Error, datasources: Datasource[]) => void) => void
-  
+
   // Get datasource details
   getDatasource: (datasourceId: number, go: (error: Error, datasource: Datasource) => void) => void
-  
+
   // Update a datasource
   updateDatasource: (datasourceId: number, name: string, description: string, path: string, go: (error: Error) => void) => void
-  
+
   // Delete a datasource
   deleteDatasource: (datasourceId: number, go: (error: Error) => void) => void
-  
+
   // Create a dataset
   createDataset: (clusterId: number, datasourceId: number, name: string, description: string, responseColumnName: string, go: (error: Error, datasetId: number) => void) => void
-  
+
   // List datasets
   getDatasets: (datasourceId: number, offset: number, limit: number, go: (error: Error, datasets: Dataset[]) => void) => void
-  
+
   // Get dataset details
   getDataset: (datasetId: number, go: (error: Error, dataset: Dataset) => void) => void
-  
+
   // Get a list of datasets on a cluster
   getDatasetsFromCluster: (clusterId: number, go: (error: Error, dataset: Dataset[]) => void) => void
-  
+
   // Update a dataset
   updateDataset: (datasetId: number, name: string, description: string, responseColumnName: string, go: (error: Error) => void) => void
-  
+
   // Split a dataset
   splitDataset: (datasetId: number, ratio1: number, ratio2: number, go: (error: Error, datasetIds: number[]) => void) => void
-  
+
   // Delete a dataset
   deleteDataset: (datasetId: number, go: (error: Error) => void) => void
-  
+
   // Build a model
   buildModel: (clusterId: number, datasetId: number, algorithm: string, go: (error: Error, modelId: number) => void) => void
-  
+
   // Build an AutoML model
   buildModelAuto: (clusterId: number, dataset: string, targetName: string, maxRunTime: number, go: (error: Error, model: Model) => void) => void
-  
+
   // Get model details
   getModel: (modelId: number, go: (error: Error, model: Model) => void) => void
-  
+
   // List models
   getModels: (projectId: number, offset: number, limit: number, go: (error: Error, models: Model[]) => void) => void
-  
+
   // List models from a cluster
   getModelsFromCluster: (clusterId: number, frameKey: string, go: (error: Error, models: Model[]) => void) => void
-  
+
   // Get a count models in a project
   findModelsCount: (projectId: number, go: (error: Error, count: number) => void) => void
-  
+
   // List sort criteria for a binomial models
   getAllBinomialSortCriteria: (go: (error: Error, criteria: string[]) => void) => void
-  
+
   // List binomial models
   findModelsBinomial: (projectId: number, namePart: string, sortBy: string, ascending: boolean, offset: number, limit: number, go: (error: Error, models: BinomialModel[]) => void) => void
-  
+
   // View a binomial model
   getModelBinomial: (modelId: number, go: (error: Error, model: BinomialModel) => void) => void
-  
+
   // List sort criteria for a multinomial models
   getAllMultinomialSortCriteria: (go: (error: Error, criteria: string[]) => void) => void
-  
+
   // List multinomial models
   findModelsMultinomial: (projectId: number, namePart: string, sortBy: string, ascending: boolean, offset: number, limit: number, go: (error: Error, models: MultinomialModel[]) => void) => void
-  
+
   // View a binomial model
   getModelMultinomial: (modelId: number, go: (error: Error, model: MultinomialModel) => void) => void
-  
+
   // List sort criteria for a regression models
   getAllRegressionSortCriteria: (go: (error: Error, criteria: string[]) => void) => void
-  
+
   // List regression models
   findModelsRegression: (projectId: number, namePart: string, sortBy: string, ascending: boolean, offset: number, limit: number, go: (error: Error, models: RegressionModel[]) => void) => void
-  
+
   // View a binomial model
   getModelRegression: (modelId: number, go: (error: Error, model: RegressionModel) => void) => void
-  
+
   // Import models from a cluster
   importModelFromCluster: (clusterId: number, projectId: number, modelKey: string, modelName: string, go: (error: Error, modelId: number) => void) => void
-  
+
   // Check if a model category can generate MOJOs
   checkMojo: (algo: string, go: (error: Error, canMojo: boolean) => void) => void
-  
+
   // Import a model's POJO from a cluster
   importModelPojo: (modelId: number, go: (error: Error) => void) => void
-  
+
   // Import a model's MOJO from a cluster
   importModelMojo: (modelId: number, go: (error: Error) => void) => void
-  
+
   // Delete a model
   deleteModel: (modelId: number, go: (error: Error) => void) => void
-  
+
   // Create a label
   createLabel: (projectId: number, name: string, description: string, go: (error: Error, labelId: number) => void) => void
-  
+
   // Update a label
   updateLabel: (labelId: number, name: string, description: string, go: (error: Error) => void) => void
-  
+
   // Delete a label
   deleteLabel: (labelId: number, go: (error: Error) => void) => void
-  
+
   // Label a model
   linkLabelWithModel: (labelId: number, modelId: number, go: (error: Error) => void) => void
-  
+
   // Remove a label from a model
   unlinkLabelFromModel: (labelId: number, modelId: number, go: (error: Error) => void) => void
-  
+
   // List labels for a project, with corresponding models, if any
   getLabelsForProject: (projectId: number, go: (error: Error, labels: Label[]) => void) => void
-  
+
   // Start a service
   startService: (modelId: number, name: string, packageName: string, go: (error: Error, serviceId: number) => void) => void
-  
+
   // Stop a service
   stopService: (serviceId: number, go: (error: Error) => void) => void
-  
+
   // Get service details
   getService: (serviceId: number, go: (error: Error, service: ScoringService) => void) => void
-  
+
   // List all services
   getServices: (offset: number, limit: number, go: (error: Error, services: ScoringService[]) => void) => void
-  
+
   // List services for a project
   getServicesForProject: (projectId: number, offset: number, limit: number, go: (error: Error, services: ScoringService[]) => void) => void
-  
+
   // List services for a model
   getServicesForModel: (modelId: number, offset: number, limit: number, go: (error: Error, services: ScoringService[]) => void) => void
-  
+
   // Delete a service
   deleteService: (serviceId: number, go: (error: Error) => void) => void
-  
+
   // Get engine details
   getEngine: (engineId: number, go: (error: Error, engine: Engine) => void) => void
-  
+
   // List engines
   getEngines: (go: (error: Error, engines: Engine[]) => void) => void
-  
+
   // Delete an engine
   deleteEngine: (engineId: number, go: (error: Error) => void) => void
-  
+
   // List all entity types
   getAllEntityTypes: (go: (error: Error, entityTypes: EntityType[]) => void) => void
-  
+
   // List all permissions
   getAllPermissions: (go: (error: Error, permissions: Permission[]) => void) => void
-  
+
   // List all cluster types
   getAllClusterTypes: (go: (error: Error, clusterTypes: ClusterType[]) => void) => void
-  
+
   // List permissions for a role
   getPermissionsForRole: (roleId: number, go: (error: Error, permissions: Permission[]) => void) => void
-  
+
   // List permissions for an identity
   getPermissionsForIdentity: (identityId: number, go: (error: Error, permissions: Permission[]) => void) => void
-  
+
   // Create a role
   createRole: (name: string, description: string, go: (error: Error, roleId: number) => void) => void
-  
+
   // List roles
   getRoles: (offset: number, limit: number, go: (error: Error, roles: Role[]) => void) => void
-  
+
   // List roles for an identity
   getRolesForIdentity: (identityId: number, go: (error: Error, roles: Role[]) => void) => void
-  
+
   // Get role details
   getRole: (roleId: number, go: (error: Error, role: Role) => void) => void
-  
+
   // Get role details by name
   getRoleByName: (name: string, go: (error: Error, role: Role) => void) => void
-  
+
   // Update a role
   updateRole: (roleId: number, name: string, description: string, go: (error: Error) => void) => void
-  
+
   // Link a role with permissions
   linkRoleWithPermissions: (roleId: number, permissionIds: number[], go: (error: Error) => void) => void
-  
+
   // Link a role with a permission
   linkRoleWithPermission: (roleId: number, permissionId: number, go: (error: Error) => void) => void
-  
+
   // Unlink a role from a permission
   unlinkRoleFromPermission: (roleId: number, permissionId: number, go: (error: Error) => void) => void
-  
+
   // Delete a role
   deleteRole: (roleId: number, go: (error: Error) => void) => void
-  
+
   // Create a workgroup
   createWorkgroup: (name: string, description: string, go: (error: Error, workgroupId: number) => void) => void
-  
+
   // List workgroups
   getWorkgroups: (offset: number, limit: number, go: (error: Error, workgroups: Workgroup[]) => void) => void
-  
+
   // List workgroups for an identity
   getWorkgroupsForIdentity: (identityId: number, go: (error: Error, workgroups: Workgroup[]) => void) => void
-  
+
   // Get workgroup details
   getWorkgroup: (workgroupId: number, go: (error: Error, workgroup: Workgroup) => void) => void
-  
+
   // Get workgroup details by name
   getWorkgroupByName: (name: string, go: (error: Error, workgroup: Workgroup) => void) => void
-  
+
   // Update a workgroup
   updateWorkgroup: (workgroupId: number, name: string, description: string, go: (error: Error) => void) => void
-  
+
   // Delete a workgroup
   deleteWorkgroup: (workgroupId: number, go: (error: Error) => void) => void
-  
+
   // Create an identity
   createIdentity: (name: string, password: string, go: (error: Error, identityId: number) => void) => void
-  
+
   // List identities
   getIdentities: (offset: number, limit: number, go: (error: Error, identities: Identity[]) => void) => void
-  
+
   // List identities for a workgroup
   getIdentitiesForWorkgroup: (workgroupId: number, go: (error: Error, identities: Identity[]) => void) => void
-  
+
   // List identities for a role
   getIdentitiesForRole: (roleId: number, go: (error: Error, identities: Identity[]) => void) => void
-  
+
   // Get a list of identities and roles with access to an entity
   getIdentitiesForEntity: (entityType: number, entityId: number, go: (error: Error, users: UserRole[]) => void) => void
-  
+
   // Get identity details
   getIdentity: (identityId: number, go: (error: Error, identity: Identity) => void) => void
-  
+
   // Get identity details by name
   getIdentityByName: (name: string, go: (error: Error, identity: Identity) => void) => void
-  
+
   // Link an identity with a workgroup
   linkIdentityWithWorkgroup: (identityId: number, workgroupId: number, go: (error: Error) => void) => void
-  
+
   // Unlink an identity from a workgroup
   unlinkIdentityFromWorkgroup: (identityId: number, workgroupId: number, go: (error: Error) => void) => void
-  
+
   // Link an identity with a role
   linkIdentityWithRole: (identityId: number, roleId: number, go: (error: Error) => void) => void
-  
+
   // Unlink an identity from a role
   unlinkIdentityFromRole: (identityId: number, roleId: number, go: (error: Error) => void) => void
-  
+
   // Update an identity
   updateIdentity: (identityId: number, password: string, go: (error: Error) => void) => void
-  
+
   // Activate an identity
   activateIdentity: (identityId: number, go: (error: Error) => void) => void
-  
+
   // Deactivate an identity
   deactivateIdentity: (identityId: number, go: (error: Error) => void) => void
-  
+
   // Share an entity with a workgroup
   shareEntity: (kind: string, workgroupId: number, entityTypeId: number, entityId: number, go: (error: Error) => void) => void
-  
+
   // List privileges for an entity
   getPrivileges: (entityTypeId: number, entityId: number, go: (error: Error, privileges: EntityPrivilege[]) => void) => void
-  
+
   // Unshare an entity
   unshareEntity: (kind: string, workgroupId: number, entityTypeId: number, entityId: number, go: (error: Error) => void) => void
-  
+
   // List audit trail records for an entity
   getHistory: (entityTypeId: number, entityId: number, offset: number, limit: number, go: (error: Error, history: EntityHistory[]) => void) => void
-  
+
   // Create a package for a project
   createPackage: (projectId: number, name: string, go: (error: Error) => void) => void
-  
-  // List packages for a project 
+
+  // List packages for a project
   getPackages: (projectId: number, go: (error: Error, packages: string[]) => void) => void
-  
+
   // List directories in a project package
   getPackageDirectories: (projectId: number, packageName: string, relativePath: string, go: (error: Error, directories: string[]) => void) => void
-  
+
   // List files in a project package
   getPackageFiles: (projectId: number, packageName: string, relativePath: string, go: (error: Error, files: string[]) => void) => void
-  
+
   // Delete a project package
   deletePackage: (projectId: number, name: string, go: (error: Error) => void) => void
-  
+
   // Delete a directory in a project package
   deletePackageDirectory: (projectId: number, packageName: string, relativePath: string, go: (error: Error) => void) => void
-  
+
   // Delete a file in a project package
   deletePackageFile: (projectId: number, packageName: string, relativePath: string, go: (error: Error) => void) => void
-  
+
   // Set attributes on a project package
   setAttributesForPackage: (projectId: number, packageName: string, attributes: string, go: (error: Error) => void) => void
-  
+
   // List attributes for a project package
   getAttributesForPackage: (projectId: number, packageName: string, go: (error: Error, attributes: string) => void) => void
-  
+
 }
 
 // --- Messages ---
 
 interface PingServerIn {
-  
+
   input: string
-  
+
 }
 
 interface PingServerOut {
-  
+
   output: string
-  
+
 }
 
 interface GetConfigIn {
-  
+
 }
 
 interface GetConfigOut {
-  
+
   config: Config
-  
+
 }
 
 interface RegisterClusterIn {
-  
+
   address: string
-  
+
 }
 
 interface RegisterClusterOut {
-  
+
   cluster_id: number
-  
+
 }
 
 interface UnregisterClusterIn {
-  
+
   cluster_id: number
-  
+
 }
 
 interface UnregisterClusterOut {
-  
+
 }
 
 interface StartClusterOnYarnIn {
-  
+
   cluster_name: string
-  
+
   engine_id: number
-  
+
   size: number
-  
+
   memory: string
-  
+
+  secure: boolean
+
   keytab: string
-  
+
 }
 
 interface StartClusterOnYarnOut {
-  
+
   cluster_id: number
-  
+
 }
 
 interface StopClusterOnYarnIn {
-  
+
   cluster_id: number
-  
+
   keytab: string
-  
+
 }
 
 interface StopClusterOnYarnOut {
-  
+
 }
 
 interface GetClusterIn {
-  
+
   cluster_id: number
-  
+
 }
 
 interface GetClusterOut {
-  
+
   cluster: Cluster
-  
+
 }
 
 interface GetClusterOnYarnIn {
-  
+
   cluster_id: number
-  
+
 }
 
 interface GetClusterOnYarnOut {
-  
+
   cluster: YarnCluster
-  
+
 }
 
 interface GetClustersIn {
-  
+
   offset: number
-  
+
   limit: number
-  
+
 }
 
 interface GetClustersOut {
-  
+
   clusters: Cluster[]
-  
+
 }
 
 interface GetClusterStatusIn {
-  
+
   cluster_id: number
-  
+
 }
 
 interface GetClusterStatusOut {
-  
+
   cluster_status: ClusterStatus
-  
+
 }
 
 interface DeleteClusterIn {
-  
+
   cluster_id: number
-  
+
 }
 
 interface DeleteClusterOut {
-  
+
 }
 
 interface GetJobIn {
-  
+
   cluster_id: number
-  
+
   job_name: string
-  
+
 }
 
 interface GetJobOut {
-  
+
   job: Job
-  
+
 }
 
 interface GetJobsIn {
-  
+
   cluster_id: number
-  
+
 }
 
 interface GetJobsOut {
-  
+
   jobs: Job[]
-  
+
 }
 
 interface CreateProjectIn {
-  
+
   name: string
-  
+
   description: string
-  
+
   model_category: string
-  
+
 }
 
 interface CreateProjectOut {
-  
+
   project_id: number
-  
+
 }
 
 interface GetProjectsIn {
-  
+
   offset: number
-  
+
   limit: number
-  
+
 }
 
 interface GetProjectsOut {
-  
+
   projects: Project[]
-  
+
 }
 
 interface GetProjectIn {
-  
+
   project_id: number
-  
+
 }
 
 interface GetProjectOut {
-  
+
   project: Project
-  
+
 }
 
 interface DeleteProjectIn {
-  
+
   project_id: number
-  
+
 }
 
 interface DeleteProjectOut {
-  
+
 }
 
 interface CreateDatasourceIn {
-  
+
   project_id: number
-  
+
   name: string
-  
+
   description: string
-  
+
   path: string
-  
+
 }
 
 interface CreateDatasourceOut {
-  
+
   datasource_id: number
-  
+
 }
 
 interface GetDatasourcesIn {
-  
+
   project_id: number
-  
+
   offset: number
-  
+
   limit: number
-  
+
 }
 
 interface GetDatasourcesOut {
-  
+
   datasources: Datasource[]
-  
+
 }
 
 interface GetDatasourceIn {
-  
+
   datasource_id: number
-  
+
 }
 
 interface GetDatasourceOut {
-  
+
   datasource: Datasource
-  
+
 }
 
 interface UpdateDatasourceIn {
-  
+
   datasource_id: number
-  
+
   name: string
-  
+
   description: string
-  
+
   path: string
-  
+
 }
 
 interface UpdateDatasourceOut {
-  
+
 }
 
 interface DeleteDatasourceIn {
-  
+
   datasource_id: number
-  
+
 }
 
 interface DeleteDatasourceOut {
-  
+
 }
 
 interface CreateDatasetIn {
-  
+
   cluster_id: number
-  
+
   datasource_id: number
-  
+
   name: string
-  
+
   description: string
-  
+
   response_column_name: string
-  
+
 }
 
 interface CreateDatasetOut {
-  
+
   dataset_id: number
-  
+
 }
 
 interface GetDatasetsIn {
-  
+
   datasource_id: number
-  
+
   offset: number
-  
+
   limit: number
-  
+
 }
 
 interface GetDatasetsOut {
-  
+
   datasets: Dataset[]
-  
+
 }
 
 interface GetDatasetIn {
-  
+
   dataset_id: number
-  
+
 }
 
 interface GetDatasetOut {
-  
+
   dataset: Dataset
-  
+
 }
 
 interface GetDatasetsFromClusterIn {
-  
+
   cluster_id: number
-  
+
 }
 
 interface GetDatasetsFromClusterOut {
-  
+
   dataset: Dataset[]
-  
+
 }
 
 interface UpdateDatasetIn {
-  
+
   dataset_id: number
-  
+
   name: string
-  
+
   description: string
-  
+
   response_column_name: string
-  
+
 }
 
 interface UpdateDatasetOut {
-  
+
 }
 
 interface SplitDatasetIn {
-  
+
   dataset_id: number
-  
+
   ratio1: number
-  
+
   ratio2: number
-  
+
 }
 
 interface SplitDatasetOut {
-  
+
   dataset_ids: number[]
-  
+
 }
 
 interface DeleteDatasetIn {
-  
+
   dataset_id: number
-  
+
 }
 
 interface DeleteDatasetOut {
-  
+
 }
 
 interface BuildModelIn {
-  
+
   cluster_id: number
-  
+
   dataset_id: number
-  
+
   algorithm: string
-  
+
 }
 
 interface BuildModelOut {
-  
+
   model_id: number
-  
+
 }
 
 interface BuildModelAutoIn {
-  
+
   cluster_id: number
-  
+
   dataset: string
-  
+
   target_name: string
-  
+
   max_run_time: number
-  
+
 }
 
 interface BuildModelAutoOut {
-  
+
   model: Model
-  
+
 }
 
 interface GetModelIn {
-  
+
   model_id: number
-  
+
 }
 
 interface GetModelOut {
-  
+
   model: Model
-  
+
 }
 
 interface GetModelsIn {
-  
+
   project_id: number
-  
+
   offset: number
-  
+
   limit: number
-  
+
 }
 
 interface GetModelsOut {
-  
+
   models: Model[]
-  
+
 }
 
 interface GetModelsFromClusterIn {
-  
+
   cluster_id: number
-  
+
   frame_key: string
-  
+
 }
 
 interface GetModelsFromClusterOut {
-  
+
   models: Model[]
-  
+
 }
 
 interface FindModelsCountIn {
-  
+
   project_id: number
-  
+
 }
 
 interface FindModelsCountOut {
-  
+
   count: number
-  
+
 }
 
 interface GetAllBinomialSortCriteriaIn {
-  
+
 }
 
 interface GetAllBinomialSortCriteriaOut {
-  
+
   criteria: string[]
-  
+
 }
 
 interface FindModelsBinomialIn {
-  
+
   project_id: number
-  
+
   name_part: string
-  
+
   sort_by: string
-  
+
   ascending: boolean
-  
+
   offset: number
-  
+
   limit: number
-  
+
 }
 
 interface FindModelsBinomialOut {
-  
+
   models: BinomialModel[]
-  
+
 }
 
 interface GetModelBinomialIn {
-  
+
   model_id: number
-  
+
 }
 
 interface GetModelBinomialOut {
-  
+
   model: BinomialModel
-  
+
 }
 
 interface GetAllMultinomialSortCriteriaIn {
-  
+
 }
 
 interface GetAllMultinomialSortCriteriaOut {
-  
+
   criteria: string[]
-  
+
 }
 
 interface FindModelsMultinomialIn {
-  
+
   project_id: number
-  
+
   name_part: string
-  
+
   sort_by: string
-  
+
   ascending: boolean
-  
+
   offset: number
-  
+
   limit: number
-  
+
 }
 
 interface FindModelsMultinomialOut {
-  
+
   models: MultinomialModel[]
-  
+
 }
 
 interface GetModelMultinomialIn {
-  
+
   model_id: number
-  
+
 }
 
 interface GetModelMultinomialOut {
-  
+
   model: MultinomialModel
-  
+
 }
 
 interface GetAllRegressionSortCriteriaIn {
-  
+
 }
 
 interface GetAllRegressionSortCriteriaOut {
-  
+
   criteria: string[]
-  
+
 }
 
 interface FindModelsRegressionIn {
-  
+
   project_id: number
-  
+
   name_part: string
-  
+
   sort_by: string
-  
+
   ascending: boolean
-  
+
   offset: number
-  
+
   limit: number
-  
+
 }
 
 interface FindModelsRegressionOut {
-  
+
   models: RegressionModel[]
-  
+
 }
 
 interface GetModelRegressionIn {
-  
+
   model_id: number
-  
+
 }
 
 interface GetModelRegressionOut {
-  
+
   model: RegressionModel
-  
+
 }
 
 interface ImportModelFromClusterIn {
-  
+
   cluster_id: number
-  
+
   project_id: number
-  
+
   model_key: string
-  
+
   model_name: string
-  
+
 }
 
 interface ImportModelFromClusterOut {
-  
+
   model_id: number
-  
+
 }
 
 interface CheckMojoIn {
-  
+
   algo: string
-  
+
 }
 
 interface CheckMojoOut {
-  
+
   can_mojo: boolean
-  
+
 }
 
 interface ImportModelPojoIn {
-  
+
   model_id: number
-  
+
 }
 
 interface ImportModelPojoOut {
-  
+
 }
 
 interface ImportModelMojoIn {
-  
+
   model_id: number
-  
+
 }
 
 interface ImportModelMojoOut {
-  
+
 }
 
 interface DeleteModelIn {
-  
+
   model_id: number
-  
+
 }
 
 interface DeleteModelOut {
-  
+
 }
 
 interface CreateLabelIn {
-  
+
   project_id: number
-  
+
   name: string
-  
+
   description: string
-  
+
 }
 
 interface CreateLabelOut {
-  
+
   label_id: number
-  
+
 }
 
 interface UpdateLabelIn {
-  
+
   label_id: number
-  
+
   name: string
-  
+
   description: string
-  
+
 }
 
 interface UpdateLabelOut {
-  
+
 }
 
 interface DeleteLabelIn {
-  
+
   label_id: number
-  
+
 }
 
 interface DeleteLabelOut {
-  
+
 }
 
 interface LinkLabelWithModelIn {
-  
+
   label_id: number
-  
+
   model_id: number
-  
+
 }
 
 interface LinkLabelWithModelOut {
-  
+
 }
 
 interface UnlinkLabelFromModelIn {
-  
+
   label_id: number
-  
+
   model_id: number
-  
+
 }
 
 interface UnlinkLabelFromModelOut {
-  
+
 }
 
 interface GetLabelsForProjectIn {
-  
+
   project_id: number
-  
+
 }
 
 interface GetLabelsForProjectOut {
-  
+
   labels: Label[]
-  
+
 }
 
 interface StartServiceIn {
-  
+
   model_id: number
-  
+
   name: string
-  
+
   package_name: string
-  
+
 }
 
 interface StartServiceOut {
-  
+
   service_id: number
-  
+
 }
 
 interface StopServiceIn {
-  
+
   service_id: number
-  
+
 }
 
 interface StopServiceOut {
-  
+
 }
 
 interface GetServiceIn {
-  
+
   service_id: number
-  
+
 }
 
 interface GetServiceOut {
-  
+
   service: ScoringService
-  
+
 }
 
 interface GetServicesIn {
-  
+
   offset: number
-  
+
   limit: number
-  
+
 }
 
 interface GetServicesOut {
-  
+
   services: ScoringService[]
-  
+
 }
 
 interface GetServicesForProjectIn {
-  
+
   project_id: number
-  
+
   offset: number
-  
+
   limit: number
-  
+
 }
 
 interface GetServicesForProjectOut {
-  
+
   services: ScoringService[]
-  
+
 }
 
 interface GetServicesForModelIn {
-  
+
   model_id: number
-  
+
   offset: number
-  
+
   limit: number
-  
+
 }
 
 interface GetServicesForModelOut {
-  
+
   services: ScoringService[]
-  
+
 }
 
 interface DeleteServiceIn {
-  
+
   service_id: number
-  
+
 }
 
 interface DeleteServiceOut {
-  
+
 }
 
 interface GetEngineIn {
-  
+
   engine_id: number
-  
+
 }
 
 interface GetEngineOut {
-  
+
   engine: Engine
-  
+
 }
 
 interface GetEnginesIn {
-  
+
 }
 
 interface GetEnginesOut {
-  
+
   engines: Engine[]
-  
+
 }
 
 interface DeleteEngineIn {
-  
+
   engine_id: number
-  
+
 }
 
 interface DeleteEngineOut {
-  
+
 }
 
 interface GetAllEntityTypesIn {
-  
+
 }
 
 interface GetAllEntityTypesOut {
-  
+
   entity_types: EntityType[]
-  
+
 }
 
 interface GetAllPermissionsIn {
-  
+
 }
 
 interface GetAllPermissionsOut {
-  
+
   permissions: Permission[]
-  
+
 }
 
 interface GetAllClusterTypesIn {
-  
+
 }
 
 interface GetAllClusterTypesOut {
-  
+
   cluster_types: ClusterType[]
-  
+
 }
 
 interface GetPermissionsForRoleIn {
-  
+
   role_id: number
-  
+
 }
 
 interface GetPermissionsForRoleOut {
-  
+
   permissions: Permission[]
-  
+
 }
 
 interface GetPermissionsForIdentityIn {
-  
+
   identity_id: number
-  
+
 }
 
 interface GetPermissionsForIdentityOut {
-  
+
   permissions: Permission[]
-  
+
 }
 
 interface CreateRoleIn {
-  
+
   name: string
-  
+
   description: string
-  
+
 }
 
 interface CreateRoleOut {
-  
+
   role_id: number
-  
+
 }
 
 interface GetRolesIn {
-  
+
   offset: number
-  
+
   limit: number
-  
+
 }
 
 interface GetRolesOut {
-  
+
   roles: Role[]
-  
+
 }
 
 interface GetRolesForIdentityIn {
-  
+
   identity_id: number
-  
+
 }
 
 interface GetRolesForIdentityOut {
-  
+
   roles: Role[]
-  
+
 }
 
 interface GetRoleIn {
-  
+
   role_id: number
-  
+
 }
 
 interface GetRoleOut {
-  
+
   role: Role
-  
+
 }
 
 interface GetRoleByNameIn {
-  
+
   name: string
-  
+
 }
 
 interface GetRoleByNameOut {
-  
+
   role: Role
-  
+
 }
 
 interface UpdateRoleIn {
-  
+
   role_id: number
-  
+
   name: string
-  
+
   description: string
-  
+
 }
 
 interface UpdateRoleOut {
-  
+
 }
 
 interface LinkRoleWithPermissionsIn {
-  
+
   role_id: number
-  
+
   permission_ids: number[]
-  
+
 }
 
 interface LinkRoleWithPermissionsOut {
-  
+
 }
 
 interface LinkRoleWithPermissionIn {
-  
+
   role_id: number
-  
+
   permission_id: number
-  
+
 }
 
 interface LinkRoleWithPermissionOut {
-  
+
 }
 
 interface UnlinkRoleFromPermissionIn {
-  
+
   role_id: number
-  
+
   permission_id: number
-  
+
 }
 
 interface UnlinkRoleFromPermissionOut {
-  
+
 }
 
 interface DeleteRoleIn {
-  
+
   role_id: number
-  
+
 }
 
 interface DeleteRoleOut {
-  
+
 }
 
 interface CreateWorkgroupIn {
-  
+
   name: string
-  
+
   description: string
-  
+
 }
 
 interface CreateWorkgroupOut {
-  
+
   workgroup_id: number
-  
+
 }
 
 interface GetWorkgroupsIn {
-  
+
   offset: number
-  
+
   limit: number
-  
+
 }
 
 interface GetWorkgroupsOut {
-  
+
   workgroups: Workgroup[]
-  
+
 }
 
 interface GetWorkgroupsForIdentityIn {
-  
+
   identity_id: number
-  
+
 }
 
 interface GetWorkgroupsForIdentityOut {
-  
+
   workgroups: Workgroup[]
-  
+
 }
 
 interface GetWorkgroupIn {
-  
+
   workgroup_id: number
-  
+
 }
 
 interface GetWorkgroupOut {
-  
+
   workgroup: Workgroup
-  
+
 }
 
 interface GetWorkgroupByNameIn {
-  
+
   name: string
-  
+
 }
 
 interface GetWorkgroupByNameOut {
-  
+
   workgroup: Workgroup
-  
+
 }
 
 interface UpdateWorkgroupIn {
-  
+
   workgroup_id: number
-  
+
   name: string
-  
+
   description: string
-  
+
 }
 
 interface UpdateWorkgroupOut {
-  
+
 }
 
 interface DeleteWorkgroupIn {
-  
+
   workgroup_id: number
-  
+
 }
 
 interface DeleteWorkgroupOut {
-  
+
 }
 
 interface CreateIdentityIn {
-  
+
   name: string
-  
+
   password: string
-  
+
 }
 
 interface CreateIdentityOut {
-  
+
   identity_id: number
-  
+
 }
 
 interface GetIdentitiesIn {
-  
+
   offset: number
-  
+
   limit: number
-  
+
 }
 
 interface GetIdentitiesOut {
-  
+
   identities: Identity[]
-  
+
 }
 
 interface GetIdentitiesForWorkgroupIn {
-  
+
   workgroup_id: number
-  
+
 }
 
 interface GetIdentitiesForWorkgroupOut {
-  
+
   identities: Identity[]
-  
+
 }
 
 interface GetIdentitiesForRoleIn {
-  
+
   role_id: number
-  
+
 }
 
 interface GetIdentitiesForRoleOut {
-  
+
   identities: Identity[]
-  
+
 }
 
 interface GetIdentitiesForEntityIn {
-  
+
   entity_type: number
-  
+
   entity_id: number
-  
+
 }
 
 interface GetIdentitiesForEntityOut {
-  
+
   users: UserRole[]
-  
+
 }
 
 interface GetIdentityIn {
-  
+
   identity_id: number
-  
+
 }
 
 interface GetIdentityOut {
-  
+
   identity: Identity
-  
+
 }
 
 interface GetIdentityByNameIn {
-  
+
   name: string
-  
+
 }
 
 interface GetIdentityByNameOut {
-  
+
   identity: Identity
-  
+
 }
 
 interface LinkIdentityWithWorkgroupIn {
-  
+
   identity_id: number
-  
+
   workgroup_id: number
-  
+
 }
 
 interface LinkIdentityWithWorkgroupOut {
-  
+
 }
 
 interface UnlinkIdentityFromWorkgroupIn {
-  
+
   identity_id: number
-  
+
   workgroup_id: number
-  
+
 }
 
 interface UnlinkIdentityFromWorkgroupOut {
-  
+
 }
 
 interface LinkIdentityWithRoleIn {
-  
+
   identity_id: number
-  
+
   role_id: number
-  
+
 }
 
 interface LinkIdentityWithRoleOut {
-  
+
 }
 
 interface UnlinkIdentityFromRoleIn {
-  
+
   identity_id: number
-  
+
   role_id: number
-  
+
 }
 
 interface UnlinkIdentityFromRoleOut {
-  
+
 }
 
 interface UpdateIdentityIn {
-  
+
   identity_id: number
-  
+
   password: string
-  
+
 }
 
 interface UpdateIdentityOut {
-  
+
 }
 
 interface ActivateIdentityIn {
-  
+
   identity_id: number
-  
+
 }
 
 interface ActivateIdentityOut {
-  
+
 }
 
 interface DeactivateIdentityIn {
-  
+
   identity_id: number
-  
+
 }
 
 interface DeactivateIdentityOut {
-  
+
 }
 
 interface ShareEntityIn {
-  
+
   kind: string
-  
+
   workgroup_id: number
-  
+
   entity_type_id: number
-  
+
   entity_id: number
-  
+
 }
 
 interface ShareEntityOut {
-  
+
 }
 
 interface GetPrivilegesIn {
-  
+
   entity_type_id: number
-  
+
   entity_id: number
-  
+
 }
 
 interface GetPrivilegesOut {
-  
+
   privileges: EntityPrivilege[]
-  
+
 }
 
 interface UnshareEntityIn {
-  
+
   kind: string
-  
+
   workgroup_id: number
-  
+
   entity_type_id: number
-  
+
   entity_id: number
-  
+
 }
 
 interface UnshareEntityOut {
-  
+
 }
 
 interface GetHistoryIn {
-  
+
   entity_type_id: number
-  
+
   entity_id: number
-  
+
   offset: number
-  
+
   limit: number
-  
+
 }
 
 interface GetHistoryOut {
-  
+
   history: EntityHistory[]
-  
+
 }
 
 interface CreatePackageIn {
-  
+
   project_id: number
-  
+
   name: string
-  
+
 }
 
 interface CreatePackageOut {
-  
+
 }
 
 interface GetPackagesIn {
-  
+
   project_id: number
-  
+
 }
 
 interface GetPackagesOut {
-  
+
   packages: string[]
-  
+
 }
 
 interface GetPackageDirectoriesIn {
-  
+
   project_id: number
-  
+
   package_name: string
-  
+
   relative_path: string
-  
+
 }
 
 interface GetPackageDirectoriesOut {
-  
+
   directories: string[]
-  
+
 }
 
 interface GetPackageFilesIn {
-  
+
   project_id: number
-  
+
   package_name: string
-  
+
   relative_path: string
-  
+
 }
 
 interface GetPackageFilesOut {
-  
+
   files: string[]
-  
+
 }
 
 interface DeletePackageIn {
-  
+
   project_id: number
-  
+
   name: string
-  
+
 }
 
 interface DeletePackageOut {
-  
+
 }
 
 interface DeletePackageDirectoryIn {
-  
+
   project_id: number
-  
+
   package_name: string
-  
+
   relative_path: string
-  
+
 }
 
 interface DeletePackageDirectoryOut {
-  
+
 }
 
 interface DeletePackageFileIn {
-  
+
   project_id: number
-  
+
   package_name: string
-  
+
   relative_path: string
-  
+
 }
 
 interface DeletePackageFileOut {
-  
+
 }
 
 interface SetAttributesForPackageIn {
-  
+
   project_id: number
-  
+
   package_name: string
-  
+
   attributes: string
-  
+
 }
 
 interface SetAttributesForPackageOut {
-  
+
 }
 
 interface GetAttributesForPackageIn {
-  
+
   project_id: number
-  
+
   package_name: string
-  
+
 }
 
 interface GetAttributesForPackageOut {
-  
+
   attributes: string
-  
+
 }
 
 
@@ -2381,8 +2383,8 @@ export function unregisterCluster(clusterId: number, go: (error: Error) => void)
   });
 }
 
-export function startClusterOnYarn(clusterName: string, engineId: number, size: number, memory: string, keytab: string, go: (error: Error, clusterId: number) => void): void {
-  const req: StartClusterOnYarnIn = { cluster_name: clusterName, engine_id: engineId, size: size, memory: memory, keytab: keytab };
+export function startClusterOnYarn(clusterName: string, engineId: number, size: number, memory: string, secure: boolean, keytab: string, go: (error: Error, clusterId: number) => void): void {
+  const req: StartClusterOnYarnIn = { cluster_name: clusterName, engine_id: engineId, size: size, memory: memory, secure: secure, keytab: keytab };
   Proxy.Call("StartClusterOnYarn", req, function(error, data) {
     if (error) {
       return go(error, null);

--- a/lib/fs/fs.go
+++ b/lib/fs/fs.go
@@ -25,7 +25,6 @@ import (
 	"io/ioutil"
 	"mime"
 	"net"
-	"net/http"
 	"net/url"
 	"os"
 	"os/exec"
@@ -38,6 +37,7 @@ import (
 
 	uuid "github.com/nu7hatch/gouuid"
 	"github.com/pkg/errors"
+	"net/http"
 )
 
 const (
@@ -462,8 +462,21 @@ func GetExternalHost() (string, error) {
 	return "", fmt.Errorf("Failed determining external IP address.")
 }
 
-func Download(p, u string, preserveFilename bool) (int64, string, error) {
-	res, err := http.Get(u)
+func Get(url, token string) (*http.Response, error) {
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if token != "" {
+		req.Header.Set("Authorization", "Basic "+token)
+	}
+
+	return http.DefaultClient.Do(req)
+}
+
+func Download(token, p, u string, preserveFilename bool) (int64, string, error) {
+	res, err := Get(u, token)
 	if err != nil {
 		return 0, "", fmt.Errorf("File download failed: %s: %v", u, err)
 	}

--- a/lib/haproxy/haproxy.go
+++ b/lib/haproxy/haproxy.go
@@ -1,0 +1,87 @@
+package haproxy
+
+import (
+	"github.com/h2oai/steam/master/data"
+	"os/exec"
+	"crypto/md5"
+	"encoding/hex"
+	"encoding/base64"
+	"syscall"
+	"context"
+
+	"github.com/pkg/errors"
+
+	"os"
+	"io/ioutil"
+)
+
+func Reload(clusters []data.Cluster, uid, gid uint32) error {
+	config :=
+		"global\n" +
+		"    daemon\n\n" +
+		"defaults\n" +
+		"    mode http\n" +
+		"    timeout connect 5000ms\n" +
+		"    timeout client  50000ms\n" +
+		"    timeout server  50000ms\n\n" +
+		"frontend h2o-clusters\n" +
+		"    bind *:9999\n"
+
+	for _, c := range clusters {
+		config +=
+			"    acl cluster_" + c.Name + " path_beg /" + c.Name + "/\n" +
+			"    use_backend " + c.Name + " if " + "cluster_" + c.Name + "\n\n"
+	}
+
+	for _, c := range clusters {
+		config += "backend " + c.Name + "\n" +
+			"    http-request set-header Authorization \"Basic %[req.cook(" + c.Name + ")]\"\n" +
+			"    server " + c.Name + " " + c.Address + "\n\n"
+	}
+
+	if err := ioutil.WriteFile("haproxy.conf",
+		[]byte(config), 0644); err != nil {
+		return err
+	}
+
+	pids, _ := ioutil.ReadFile("haproxy.pid")
+	args := []string{
+		"-f", "haproxy.conf",
+		"-p", "haproxy.pid",
+		"-d", "-D",
+		"-sf", string(pids),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "haproxy", args...)
+	cmd.SysProcAttr = &syscall.SysProcAttr{}
+	cmd.SysProcAttr.Credential = &syscall.Credential{Uid: uid, Gid: gid}
+
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	// Execute command
+	if err := cmd.Run(); err != nil {
+		return errors.Wrapf(err, "failed running command %s", cmd.Args)
+	}
+
+	return nil
+}
+
+func GenRealmFile(username, passwd string) (string, error) {
+	entry := username + ": MD5:" + GetMD5Hash(passwd)
+	token := base64.StdEncoding.EncodeToString([]byte(username + ":" + passwd))
+	if err := ioutil.WriteFile(token + "_realm.properties", []byte(entry), 0644); err != nil {
+		return "", err
+	}
+	return token, nil
+}
+
+
+func GetMD5Hash(text string) string {
+	hasher := md5.New()
+	hasher.Write([]byte(text))
+	return hex.EncodeToString(hasher.Sum(nil))
+}

--- a/lib/haproxy/haproxy.go
+++ b/lib/haproxy/haproxy.go
@@ -30,7 +30,7 @@ func Reload(clusters []data.Cluster, uid, gid uint32) error {
 	for _, c := range clusters {
 		if c.ContextPath != "/" {
 			config +=
-				"    acl cluster_" + c.Name + " path_beg " + c.ContextPath + "/\n" +
+				"    acl cluster_" + c.Name + " path_beg " + c.ContextPath + "\n" +
 				"    use_backend " + c.Name + " if " + "cluster_" + c.Name + "\n\n"
 		}
 	}

--- a/lib/haproxy/haproxy.go
+++ b/lib/haproxy/haproxy.go
@@ -36,7 +36,7 @@ func Reload(clusters []data.Cluster, uid, gid uint32) error {
 	for _, c := range clusters {
 		config += "backend " + c.Name + "\n"
 		if c.Token != "" {
-			config += "    http-request set-header Authorization \"Basic %[req.cook(" + c.Name + ")]\"\n"
+			config += "    http-request set-header Authorization Basic\\ %[req.cook(" + c.Name + ")]\n"
 		}
 		config += "    server " + c.Name + " " + c.Address + "\n\n"
 	}
@@ -46,16 +46,15 @@ func Reload(clusters []data.Cluster, uid, gid uint32) error {
 		return err
 	}
 
-	pids, _ := ioutil.ReadFile("haproxy.pid")
-	if pids == nil {
-		pids = []byte{}
-	}
-
 	args := []string{
 		"-f", "haproxy.conf",
 		"-p", "haproxy.pid",
 		"-d", "-D",
-		"-sf", string(pids),
+	}
+
+	pids, _ := ioutil.ReadFile("haproxy.pid")
+	if pids != nil {
+		args = append(args, "-sf", string(pids))
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/lib/haproxy/haproxy.go
+++ b/lib/haproxy/haproxy.go
@@ -34,9 +34,11 @@ func Reload(clusters []data.Cluster, uid, gid uint32) error {
 	}
 
 	for _, c := range clusters {
-		config += "backend " + c.Name + "\n" +
-			"    http-request set-header Authorization \"Basic %[req.cook(" + c.Name + ")]\"\n" +
-			"    server " + c.Name + " " + c.Address + "\n\n"
+		config += "backend " + c.Name + "\n"
+		if c.Token != "" {
+			config += "    http-request set-header Authorization \"Basic %[req.cook(" + c.Name + ")]\"\n"
+		}
+		config += "    server " + c.Name + " " + c.Address + "\n\n"
 	}
 
 	if err := ioutil.WriteFile("haproxy.conf",
@@ -45,6 +47,10 @@ func Reload(clusters []data.Cluster, uid, gid uint32) error {
 	}
 
 	pids, _ := ioutil.ReadFile("haproxy.pid")
+	if pids == nil {
+		pids = []byte{}
+	}
+
 	args := []string{
 		"-f", "haproxy.conf",
 		"-p", "haproxy.pid",

--- a/lib/yarn/yarn.go
+++ b/lib/yarn/yarn.go
@@ -213,7 +213,7 @@ func StartCloud(size int, kerberos bool, mem, name, enginePath, username, keytab
 		"-disown",
 	}
 
-	contextPath := "/"
+	contextPath := ""
 	cpe := contextPathEnabledEngine(enginePath, uid, gid)
 	if cpe {
 		contextPathArgs := []string{"-J", "-context_path", "-J", "/" + name}
@@ -236,7 +236,7 @@ func StartCloud(size int, kerberos bool, mem, name, enginePath, username, keytab
 		return "", "", "", "", "", errors.Wrap(err, "failed executing command")
 	}
 
-	return appID, address, out, token, contextPath, nil
+	return appID, address, out, token, contextPath + "/", nil
 }
 
 func contextPathEnabledEngine(enginePath string, uid, gid uint32) bool {

--- a/lib/yarn/yarn.go
+++ b/lib/yarn/yarn.go
@@ -102,7 +102,7 @@ func contextParamScan(r io.ReadCloser, contextEnabled *string) {
 	for in.Scan() {
 		if in.Text() != "" {
 			if contextEnabled != nil {
-				if strings.Contains(in.Text(), "-AAAAAAAAAcontext_path") {
+				if strings.Contains(in.Text(), "-context_path") {
 					*contextEnabled = "enabled"
 				}
 			}

--- a/lib/yarn/yarn.go
+++ b/lib/yarn/yarn.go
@@ -102,7 +102,7 @@ func contextParamScan(r io.ReadCloser, contextEnabled *string) {
 	for in.Scan() {
 		if in.Text() != "" {
 			if contextEnabled != nil {
-				if strings.Contains(in.Text(), "-context_path") {
+				if strings.Contains(in.Text(), "-AAAAAAAAAcontext_path") {
 					*contextEnabled = "enabled"
 				}
 			}

--- a/master/data/db.go
+++ b/master/data/db.go
@@ -2435,7 +2435,7 @@ func (ds *Datastore) CreateExternalCluster(pz az.Principal, name, address, state
 	return id, err
 }
 
-func (ds *Datastore) CreateYarnCluster(pz az.Principal, name, address, token, state string, cluster YarnCluster) (int64, error) {
+func (ds *Datastore) CreateYarnCluster(pz az.Principal, name, contextPath, address, token, state string, cluster YarnCluster) (int64, error) {
 	var clusterId int64
 	err := ds.exec(func(tx *sql.Tx) error {
 		var yarnClusterId int64
@@ -2464,10 +2464,10 @@ func (ds *Datastore) CreateYarnCluster(pz az.Principal, name, address, token, st
 		res, err := tx.Exec(`
 			INSERT INTO
 				cluster
-				(name, type_id, detail_id, address, token, state, created)
+				(name, context_path, type_id, detail_id, address, token, state, created)
 			VALUES
-				($1,   $2,      $3,        $4,      $5,      $6,    datetime('now'))
-			`, name, ds.ClusterTypes.Yarn, yarnClusterId, address, token, state)
+				($1,   $2,      $3,        $4,      $5,      $6,      $7,    datetime('now'))
+			`, name, contextPath, ds.ClusterTypes.Yarn, yarnClusterId, address, token, state)
 		if err != nil {
 			return err
 		}
@@ -2488,6 +2488,7 @@ func (ds *Datastore) CreateYarnCluster(pz az.Principal, name, address, token, st
 
 		return ds.audit(pz, tx, CreateOp, ds.EntityTypes.Cluster, clusterId, metadata{
 			"name":            name,
+			"contextPath":     contextPath,
 			"type":            ClusterYarn,
 			"address":         address,
 			"token": 	   token,
@@ -2510,7 +2511,7 @@ func (ds *Datastore) ReadClusterTypes(pz az.Principal) []ClusterType {
 func (ds *Datastore) ReadClusters(pz az.Principal, offset, limit int64) ([]Cluster, error) {
 	rows, err := ds.db.Query(`
 		SELECT
-			id, name, type_id, detail_id, address, token, state, created
+			id, name, context_path, type_id, detail_id, address, token, state, created
 		FROM
 			cluster
 		WHERE
@@ -2549,7 +2550,7 @@ func (ds *Datastore) ReadCluster(pz az.Principal, clusterId int64) (Cluster, err
 	}
 	row := ds.db.QueryRow(`
 		SELECT
-			id, name, type_id, detail_id, address, token, state, created
+			id, name, context_path, type_id, detail_id, address, token, state, created
 		FROM
 			cluster
 		WHERE
@@ -2563,7 +2564,7 @@ func (ds *Datastore) ReadClusterByAddress(pz az.Principal, address string) (Clus
 	var cluster Cluster
 	rows, err := ds.db.Query(`
 		SELECT
-			id, name, type_id, detail_id, address, token, state, created
+			id, name, context_path, type_id, detail_id, address, token, state, created
 		FROM
 			cluster
 		WHERE
@@ -2582,7 +2583,7 @@ func (ds *Datastore) ReadClusterByName(pz az.Principal, name string) (Cluster, b
 	var cluster Cluster
 	rows, err := ds.db.Query(`
 		SELECT
-			id, name, type_id, detail_id, address, token, state, created
+			id, name, context_path, type_id, detail_id, address, token, state, created
 		FROM
 			cluster
 		WHERE
@@ -2599,7 +2600,7 @@ func (ds *Datastore) ReadClusterByName(pz az.Principal, name string) (Cluster, b
 func (ds *Datastore) ReadAllClusters(pz az.Principal) ([]Cluster, error) {
 	rows, err := ds.db.Query(`
 		SELECT
-			id, name, type_id, detail_id, address, token, state, created
+			id, name, context_path, type_id, detail_id, address, token, state, created
 		FROM
 			cluster
 		`)

--- a/master/data/db.go
+++ b/master/data/db.go
@@ -2399,13 +2399,14 @@ func (ds *Datastore) DeleteEngine(pz az.Principal, engineId int64) error {
 func (ds *Datastore) CreateExternalCluster(pz az.Principal, name, address, state string) (int64, error) {
 	var id int64
 	err := ds.exec(func(tx *sql.Tx) error {
+		// TODO we might want to allow the user to pass the context_path from the UI
 		res, err := tx.Exec(`
 			INSERT INTO
 				cluster
-				(name, type_id, detail_id, address, token, state, created)
+				(name, context_path, type_id, detail_id, address, token, state, created)
 			VALUES
-				($1,   $2,      0,         $3,      $4,      $5,    datetime('now'))
-			`, name, ds.ClusterTypes.External, address, "", state)
+				($1,   $2,      $3,      0,      $4,      $5,      $6,    datetime('now'))
+			`, name, "/", ds.ClusterTypes.External, address, "", state)
 		// TODO add token?!
 		if err != nil {
 			return err

--- a/master/data/db_test.go
+++ b/master/data/db_test.go
@@ -804,7 +804,7 @@ func TestYarnClusters(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	id1, err := ds.CreateYarnCluster(p, "cluster1", "address1", "started", YarnCluster{
+	id1, err := ds.CreateYarnCluster(p, "cluster1", "address1", "", "started", YarnCluster{
 		0,
 		eid,
 		4,
@@ -818,7 +818,7 @@ func TestYarnClusters(t *testing.T) {
 	}
 	t.Log(id1)
 
-	id2, err := ds.CreateYarnCluster(p, "cluster2", "address2", "started", YarnCluster{
+	id2, err := ds.CreateYarnCluster(p, "cluster2", "address2", "", "started", YarnCluster{
 		0,
 		eid,
 		4,

--- a/master/data/db_test.go
+++ b/master/data/db_test.go
@@ -804,7 +804,7 @@ func TestYarnClusters(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	id1, err := ds.CreateYarnCluster(p, "cluster1", "address1", "", "started", YarnCluster{
+	id1, err := ds.CreateYarnCluster(p, "cluster1", "", "address1", "", "started", YarnCluster{
 		0,
 		eid,
 		4,
@@ -818,7 +818,7 @@ func TestYarnClusters(t *testing.T) {
 	}
 	t.Log(id1)
 
-	id2, err := ds.CreateYarnCluster(p, "cluster2", "address2", "", "started", YarnCluster{
+	id2, err := ds.CreateYarnCluster(p, "cluster2", "", "address2", "", "started", YarnCluster{
 		0,
 		eid,
 		4,

--- a/master/data/models.go
+++ b/master/data/models.go
@@ -124,6 +124,7 @@ type Cluster struct {
 	DetailId int64
 	Address  string
 	State    string
+	Token    string
 	Created  time.Time
 }
 

--- a/master/data/models.go
+++ b/master/data/models.go
@@ -118,14 +118,15 @@ type ClusterType struct {
 }
 
 type Cluster struct {
-	Id       int64
-	Name     string
-	TypeId   int64
-	DetailId int64
-	Address  string
-	State    string
-	Token    string
-	Created  time.Time
+	Id       	int64
+	Name     	string
+	ContextPath	string
+	TypeId   	int64
+	DetailId 	int64
+	Address  	string
+	State    	string
+	Token    	string
+	Created  	time.Time
 }
 
 type YarnCluster struct {

--- a/master/data/scans.go
+++ b/master/data/scans.go
@@ -454,6 +454,7 @@ func ScanCluster(r *sql.Row) (Cluster, error) {
 		&s.TypeId,
 		&s.DetailId,
 		&s.Address,
+		&s.Token,
 		&s.State,
 		&s.Created,
 	); err != nil {
@@ -473,6 +474,7 @@ func ScanClusters(rs *sql.Rows) ([]Cluster, error) {
 			&s.TypeId,
 			&s.DetailId,
 			&s.Address,
+			&s.Token,
 			&s.State,
 			&s.Created,
 		); err != nil {

--- a/master/data/scans.go
+++ b/master/data/scans.go
@@ -451,6 +451,7 @@ func ScanCluster(r *sql.Row) (Cluster, error) {
 	if err := r.Scan(
 		&s.Id,
 		&s.Name,
+		&s.ContextPath,
 		&s.TypeId,
 		&s.DetailId,
 		&s.Address,
@@ -471,6 +472,7 @@ func ScanClusters(rs *sql.Rows) ([]Cluster, error) {
 		if err = rs.Scan(
 			&s.Id,
 			&s.Name,
+			&s.ContextPath,
 			&s.TypeId,
 			&s.DetailId,
 			&s.Address,

--- a/scripts/database/create-schema.sql
+++ b/scripts/database/create-schema.sql
@@ -141,6 +141,7 @@ CREATE TABLE cluster (
     type_id integer NOT NULL,
     detail_id integer NOT NULL,
     address text NOT NULL,
+    token text NOT NULL,
     state job_state NOT NULL,
     created datetime NOT NULL,
 

--- a/scripts/database/create-schema.sql
+++ b/scripts/database/create-schema.sql
@@ -138,6 +138,7 @@ CREATE TABLE binomial_model (
 CREATE TABLE cluster (
     id integer PRIMARY KEY AUTOINCREMENT,
     name text NOT NULL,
+    context_path text NOT NULL,
     type_id integer NOT NULL,
     detail_id integer NOT NULL,
     address text NOT NULL,

--- a/srv/h2ov3/delete.go
+++ b/srv/h2ov3/delete.go
@@ -34,11 +34,15 @@ import (
 // DeleteInitIDEndsession End a session. */
 func (h *H2O) DeleteInitIDEndsession() (*bindings.InitIDV3, error) {
 	//@DELETE
-	u := h.url("/3/InitID")
+	u := h.url("3/InitID")
 
 	req, err := http.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error making delete request: %s: %s", u, err)
+	}
+
+	if h.Token != "" {
+		req.Header.Set("Authorization", "Basic "+h.Token)
 	}
 
 	res, err := http.DefaultClient.Do(req)

--- a/srv/h2ov3/get.go
+++ b/srv/h2ov3/get.go
@@ -26,6 +26,19 @@ import (
 	"github.com/h2oai/steam/bindings"
 )
 
+func (h *H2O) Get(url string) (*http.Response, error) {
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if h.Token != "" {
+		req.Header.Set("Authorization", "Basic "+h.Token)
+	}
+
+	return h.Client.Do(req)
+}
+
 ///////////////////
 ///////////////////
 ////// Cloud //////
@@ -33,17 +46,11 @@ import (
 ///////////////////
 
 // GetCloudStatus Determine the status of the nodes in the H2O cloud.
-func (h *H2O) GetCloudStatus(token, contextPath string) (*bindings.CloudV3, error) {
+func (h *H2O) GetCloudStatus(token string) (*bindings.CloudV3, error) {
 	//@GET
-	u := h.url(contextPath + "/3/Cloud")
+	u := h.url("3/Cloud")
 
-	req, _ := http.NewRequest("GET", u, nil)
-	if token != "" {
-		req.Header.Set("Authorization", "Basic "+token)
-	}
-
-	client := &http.Client {}
-	res, err := client.Do(req)
+	res, err := h.Get(u)
 
 	if err != nil {
 		return nil, fmt.Errorf("H2O get request failed: %s: %s", u, err)
@@ -70,10 +77,10 @@ func (h *H2O) GetCloudStatus(token, contextPath string) (*bindings.CloudV3, erro
 // GetFramesFetch Return the specified Frame. */
 func (h *H2O) GetFramesFetch(frame_id string, find_compatible_models bool) ([]byte, *bindings.FramesV3, error) {
 	//@GET
-	u := h.url("/3/Frames/?{frame_id}", frame_id)
+	u := h.url("3/Frames/?{frame_id}", frame_id)
 	u = u + "?find_compatible_models=" + strconv.FormatBool(find_compatible_models)
 
-	res, err := http.Get(u)
+	res, err := h.Get(u)
 	if err != nil {
 		return nil, nil, fmt.Errorf("H2O get request failed: %s: %s", u, err)
 	}
@@ -94,9 +101,9 @@ func (h *H2O) GetFramesFetch(frame_id string, find_compatible_models bool) ([]by
 // GetFramesList Return all Frames in the H2O distributed K/V store. */
 func (h *H2O) GetFramesList() (*bindings.FramesV3, error) {
 	//@GET
-	u := h.url("/3/Frames")
+	u := h.url("3/Frames")
 
-	res, err := http.Get(u)
+	res, err := h.Get(u)
 	if err != nil {
 		return nil, fmt.Errorf("H2O get request failed: %s: %s", u, err)
 	}
@@ -123,9 +130,9 @@ func (h *H2O) GetFramesList() (*bindings.FramesV3, error) {
 // GetInitIDIssue Issue a new session ID. */
 func (h *H2O) GetInitIDIssue() (*bindings.InitIDV3, error) {
 	//@GET
-	u := h.url("/3/InitID")
+	u := h.url("3/InitID")
 
-	res, err := http.Get(u)
+	res, err := h.Get(u)
 	if err != nil {
 		return nil, fmt.Errorf("H2O get request failed: %s: %s", u, err)
 	}
@@ -152,9 +159,9 @@ func (h *H2O) GetInitIDIssue() (*bindings.InitIDV3, error) {
 // GetJobsList Get a list of all the H2O Jobs (long-running actions). */
 func (h *H2O) GetJobsList() (*bindings.JobsV3, error) {
 	//@GET
-	u := h.url("/3/Jobs")
+	u := h.url("3/Jobs")
 
-	res, err := http.Get(u)
+	res, err := h.Get(u)
 	if err != nil {
 		return nil, fmt.Errorf("H2O get request failed: %s: %s", u, err)
 	}
@@ -174,9 +181,9 @@ func (h *H2O) GetJobsList() (*bindings.JobsV3, error) {
 // GetJobsFetch Get the status of the given H2O Job (long-running action). */
 func (h *H2O) GetJobsFetch(job_id string) (*bindings.JobsV3, error) {
 	//@GET
-	u := h.url("/3/Jobs/?{job_id}", job_id)
+	u := h.url("3/Jobs/?{job_id}", job_id)
 
-	res, err := http.Get(u)
+	res, err := h.Get(u)
 	if err != nil {
 		return nil, fmt.Errorf("H2O get request failed: %s: %s", u, err)
 	}
@@ -202,9 +209,9 @@ func (h *H2O) GetJobsFetch(job_id string) (*bindings.JobsV3, error) {
 // GetModelsFetch Return the specified Model from the H2O distributed K/V store, optionally with the list of compatible Frames. */
 func (h *H2O) GetModelsFetch(model_id string) ([]byte, *bindings.ModelsV3, error) {
 	//@GET
-	u := h.url("/3/Models/?{model_id}", model_id)
+	u := h.url("3/Models/?{model_id}", model_id)
 
-	res, err := http.Get(u)
+	res, err := h.Get(u)
 	if err != nil {
 		return nil, nil, fmt.Errorf("H2O get request failed: %s: %s", u, err)
 	}
@@ -224,9 +231,9 @@ func (h *H2O) GetModelsFetch(model_id string) ([]byte, *bindings.ModelsV3, error
 // GetModelsList Return all Models from the H2O distributed K/V store. */
 func (h *H2O) GetModelsList() (*bindings.ModelsV3, error) {
 	//@GET
-	u := h.url("/3/Models")
+	u := h.url("3/Models")
 
-	res, err := http.Get(u)
+	res, err := h.Get(u)
 	if err != nil {
 		return nil, fmt.Errorf("H2O get request failed: %s: %s", u, err)
 	}
@@ -252,9 +259,9 @@ func (h *H2O) GetModelsList() (*bindings.ModelsV3, error) {
 // GetModelMetricsListSchemaFetchByModel Return the saved scoring metrics for the specified Model. */
 func (h *H2O) GetModelMetricsListSchemaFetchByModel(model string) ([]byte, *bindings.ModelMetricsListSchemaV3, error) {
 	//@GET
-	u := h.url("/3/ModelMetrics/models/?{model}", model)
+	u := h.url("3/ModelMetrics/models/?{model}", model)
 
-	res, err := http.Get(u)
+	res, err := h.Get(u)
 	if err != nil {
 		return nil, nil, fmt.Errorf("H2O get request failed: %s: %s", u, err)
 	}

--- a/srv/h2ov3/get.go
+++ b/srv/h2ov3/get.go
@@ -33,11 +33,18 @@ import (
 ///////////////////
 
 // GetCloudStatus Determine the status of the nodes in the H2O cloud.
-func (h *H2O) GetCloudStatus() (*bindings.CloudV3, error) {
+func (h *H2O) GetCloudStatus(token, contextPath string) (*bindings.CloudV3, error) {
 	//@GET
-	u := h.url("/3/Cloud")
+	u := h.url(contextPath + "/3/Cloud")
 
-	res, err := http.Get(u)
+	req, _ := http.NewRequest("GET", u, nil)
+	if token != "" {
+		req.Header.Set("Authorization", "Basic "+token)
+	}
+
+	client := &http.Client {}
+	res, err := client.Do(req)
+
 	if err != nil {
 		return nil, fmt.Errorf("H2O get request failed: %s: %s", u, err)
 	}

--- a/srv/h2ov3/post.go
+++ b/srv/h2ov3/post.go
@@ -25,7 +25,25 @@ import (
 	"strconv"
 
 	"github.com/h2oai/steam/bindings"
+	"strings"
 )
+
+func (h *H2O) PostForm(url string, data url.Values) (resp *http.Response, err error) {
+	bodyType := "application/x-www-form-urlencoded"
+	body := strings.NewReader(data.Encode())
+
+	req, err := http.NewRequest("POST", url, body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", bodyType)
+
+	if h.Token != "" {
+		req.Header.Set("Authorization", "Basic "+h.Token)
+	}
+
+	return h.Client.Do(req)
+}
 
 /////////////////////////
 /////////////////////////
@@ -36,14 +54,14 @@ import (
 // PostImportFilesImportfiles Import raw data files into a single-column H2O Frame. */
 func (h *H2O) PostImportFilesImportfiles(path string) (*bindings.ImportFilesV3, error) {
 	//@POST
-	u := h.url("/3/ImportFiles")
+	u := h.url("3/ImportFiles")
 
 	// FIXME: remaining URL values req'd
 	v := url.Values{
 		"path": {path},
 	}
 
-	res, err := http.PostForm(u, v)
+	res, err := h.PostForm(u, v)
 	if err != nil {
 		return nil, fmt.Errorf("H2O post request failed: %s: %s", u, err)
 	}
@@ -69,7 +87,7 @@ func (h *H2O) PostImportFilesImportfiles(path string) (*bindings.ImportFilesV3, 
 // PostParseParse Parse a raw byte-oriented Frame into a useful columnar data Frame. */
 func (h *H2O) PostParseParse(in *bindings.ParseV3) (*bindings.ParseV3, error) {
 	//@POST
-	u := h.url("/3/Parse")
+	u := h.url("3/Parse")
 
 	defaultParse := bindings.NewParseV3()
 
@@ -119,7 +137,7 @@ func (h *H2O) PostParseParse(in *bindings.ParseV3) (*bindings.ParseV3, error) {
 		v["_exclude_fields"] = []string{}
 	}
 
-	res, err := http.PostForm(u, v)
+	res, err := h.PostForm(u, v)
 	if err != nil {
 		return nil, err
 	}
@@ -145,14 +163,14 @@ func (h *H2O) PostParseParse(in *bindings.ParseV3) (*bindings.ParseV3, error) {
 // PostParseSetupGuesssetup Guess the parameters for parsing raw byte-oriented data into an H2O Frame. */
 func (h *H2O) PostParseSetupGuesssetup(sourceFrames []string) (*bindings.ParseSetupV3, error) {
 	//@POST
-	u := h.url("/3/ParseSetup")
+	u := h.url("3/ParseSetup")
 
 	// FIXME: remaining URL values req'd
 	v := url.Values{
 		"source_frames": sourceFrames,
 	}
 
-	res, err := http.PostForm(u, v)
+	res, err := h.PostForm(u, v)
 	if err != nil {
 		return nil, err
 	}

--- a/srv/web/api/api.go
+++ b/srv/web/api/api.go
@@ -422,6 +422,7 @@ type StartClusterOnYarn struct {
 	EngineId    int64
 	Size        int
 	Memory      string
+	Secure      bool
 	Keytab      string
 	_           int
 	ClusterId   int64

--- a/srv/web/service.go
+++ b/srv/web/service.go
@@ -64,6 +64,7 @@ type Cluster struct {
 	TypeId    int64  `json:"type_id"`
 	DetailId  int64  `json:"detail_id"`
 	Address   string `json:"address"`
+	Token     string `json:"token"`
 	State     string `json:"state"`
 	CreatedAt int64  `json:"created_at"`
 }
@@ -294,7 +295,7 @@ type Service interface {
 	GetConfig(pz az.Principal) (*Config, error)
 	RegisterCluster(pz az.Principal, address string) (int64, error)
 	UnregisterCluster(pz az.Principal, clusterId int64) error
-	StartClusterOnYarn(pz az.Principal, clusterName string, engineId int64, size int, memory string, keytab string) (int64, error)
+	StartClusterOnYarn(pz az.Principal, clusterName string, engineId int64, size int, memory string, secure bool, keytab string) (int64, error)
 	StopClusterOnYarn(pz az.Principal, clusterId int64, keytab string) error
 	GetCluster(pz az.Principal, clusterId int64) (*Cluster, error)
 	GetClusterOnYarn(pz az.Principal, clusterId int64) (*YarnCluster, error)
@@ -442,6 +443,7 @@ type StartClusterOnYarnIn struct {
 	EngineId    int64  `json:"engine_id"`
 	Size        int    `json:"size"`
 	Memory      string `json:"memory"`
+	Secure      bool   `json:"secure"`
 	Keytab      string `json:"keytab"`
 }
 
@@ -1432,8 +1434,8 @@ func (this *Remote) UnregisterCluster(clusterId int64) error {
 	return nil
 }
 
-func (this *Remote) StartClusterOnYarn(clusterName string, engineId int64, size int, memory string, keytab string) (int64, error) {
-	in := StartClusterOnYarnIn{clusterName, engineId, size, memory, keytab}
+func (this *Remote) StartClusterOnYarn(clusterName string, engineId int64, size int, memory string, secure bool, keytab string) (int64, error) {
+	in := StartClusterOnYarnIn{clusterName, engineId, size, memory, secure, keytab}
 	var out StartClusterOnYarnOut
 	err := this.Proc.Call("StartClusterOnYarn", &in, &out)
 	if err != nil {
@@ -2694,7 +2696,7 @@ func (this *Impl) StartClusterOnYarn(r *http.Request, in *StartClusterOnYarnIn, 
 		log.Println(guid, "REQ", pz, name, string(req))
 	}
 
-	val0, err := this.Service.StartClusterOnYarn(pz, in.ClusterName, in.EngineId, in.Size, in.Memory, in.Keytab)
+	val0, err := this.Service.StartClusterOnYarn(pz, in.ClusterName, in.EngineId, in.Size, in.Memory, in.Secure, in.Keytab)
 	if err != nil {
 		log.Println(guid, "ERR", pz, name, err)
 		return err

--- a/srv/web/service.go
+++ b/srv/web/service.go
@@ -59,14 +59,15 @@ type BinomialModel struct {
 }
 
 type Cluster struct {
-	Id        int64  `json:"id"`
-	Name      string `json:"name"`
-	TypeId    int64  `json:"type_id"`
-	DetailId  int64  `json:"detail_id"`
-	Address   string `json:"address"`
-	Token     string `json:"token"`
-	State     string `json:"state"`
-	CreatedAt int64  `json:"created_at"`
+	Id        	int64  `json:"id"`
+	Name      	string `json:"name"`
+	ContextPath     string `json:"context_path"`
+	TypeId    	int64  `json:"type_id"`
+	DetailId  	int64  `json:"detail_id"`
+	Address   	string `json:"address"`
+	Token     	string `json:"token"`
+	State     	string `json:"state"`
+	CreatedAt 	int64  `json:"created_at"`
 }
 
 type ClusterStatus struct {

--- a/srv/web/service.pipe
+++ b/srv/web/service.pipe
@@ -143,7 +143,7 @@ Ping(status bool) status bool
 
 RegisterCluster(address string) clusterId int64
 UnregisterCluster(clusterId int64)
-StartYarnCluster(clusterName string, engineId int64, size int, memory string, username string) clusterId int64 
+StartYarnCluster(clusterName string, engineId int64, size int, memory string, secure bool, username string) clusterId int64
 StopYarnCluster(clusterId int64)
 GetCluster(clusterId int64) cluster *Cluster
 GetYarnCluster(clusterId int64) cluster *YarnCluster


### PR DESCRIPTION
* Requires HAProxy 1.5+ to be already installed on the same machine Steam is running
* Generates HAproxy config on cluster launch/delete:
** binds on port 9999
** simple redirect based on URL path
** adds Authentication Basic header from a cookie (cookie name == cluster name)
* Generates a user/random password (username == steam username) for each new H2O cluster and starts H2O Jetty in secure mode (HashLogin) when "secure" checkbox in Steam is "on" - a base64 "user:password" token is stored in the DB (in the cluster table) 
* Adds a button to the Clusters screen for each cluster to go to them through the proxy (clicking on the name points to the clusters directly as it used to). Clicking it automatically adds a cookie (cookie name == cluster name) with the security token (from the DB) so people with the proxy URL won't be able to access it if they don't go through Steam first. 

How to test:

0) Make sure you can run `hadoop` locally (you either have a hadoop cluster set up on your machine or configured it to point to a remote one)
1) Install HAProxy 1.5+ (on mac simply `brew install haproxy`). Make sure to put it on your PATH.
2) Get this h2o-3 branch https://github.com/h2oai/h2o-3/tree/MD_context_path_doc
3) Run `./gradlew clean`
4) Get this h2o-flow branch https://github.com/h2oai/h2o-flow/tree/master
5) Run `make` in h2o-flow
6) In h2o-3 run `cp h2o-web/src/main/resources/www/flow/js/* h2o-web/lib/h2o-flow/build/js/`
7) In h2o3 build it with hadoop support https://github.com/h2oai/h2o-3/tree/MD_context_path_doc#6-building-h2o-on-hadoop
8) Pull this Steam branch, build it `go build`, clean the db `make db`
9) Run it with `sudo ./steam serve master --superuser-name=<USERNAME> --superuser-password=superuser`
10) Upload the engine you built in 6), launch a cluster (preferably with security checked)

Questions/TODOs:
1) I'm storing the token for H2O authentication in the DB, do we need a DB migration script?
2) The proxy button for each cluster is "reusing" the CSS for the trash button... Should we change that?
3) Currently using cluster name for URLs, IDs would be nicer (unique) but we get the cluster ID when its saved to the DB, which is after we start H2O - I need to pass that information to H2O so Jetty can set it as the context path, need to figure this part out.
4) We will need to add roles to cluster list so only certain people can see certain clusters.