### PR TITLE
STEAM-612: Remove duplicate `upload engine` cli

### DIFF
--- a/cli2/cli.go
+++ b/cli2/cli.go
@@ -32,7 +32,6 @@ import (
 func registerGeneratedCommands(c *context, cmd *cobra.Command) {
 	cmd.AddCommand(
 		activate(c),
-		add(c),
 		build(c),
 		check(c),
 		create(c),
@@ -98,56 +97,6 @@ func activateIdentity(c *context) *cobra.Command {
 	})
 
 	cmd.Flags().Int64Var(&identityId, "identity-id", identityId, "Integer ID of an identity in Steam.")
-	return cmd
-}
-
-var addHelp = `
-add [?]
-Add entities
-Commands:
-
-    $ steam add engine ...
-`
-
-func add(c *context) *cobra.Command {
-	cmd := newCmd(c, addHelp, nil)
-
-	cmd.AddCommand(addEngine(c))
-	return cmd
-}
-
-var addEngineHelp = `
-engine [?]
-Add Engine
-Examples:
-
-    Add an engine
-    $ steam add engine \
-        --engine-name=? \
-        --engine-path=?
-
-`
-
-func addEngine(c *context) *cobra.Command {
-	var engineName string // No description available
-	var enginePath string // No description available
-
-	cmd := newCmd(c, addEngineHelp, func(c *context, args []string) {
-
-		// Add an engine
-		engineId, err := c.remote.AddEngine(
-			engineName, // No description available
-			enginePath, // No description available
-		)
-		if err != nil {
-			log.Fatalln(err)
-		}
-		fmt.Printf("EngineId:\t%v\n", engineId)
-		return
-	})
-
-	cmd.Flags().StringVar(&engineName, "engine-name", engineName, "No description available")
-	cmd.Flags().StringVar(&enginePath, "engine-path", enginePath, "No description available")
 	return cmd
 }
 

--- a/cli2/local.go
+++ b/cli2/local.go
@@ -257,49 +257,6 @@ func serveMaster(c *context) *cobra.Command {
 
 }
 
-var deployHelp = `
-deploy [resource-type]
-Deploy a resource of the specified type.
-Examples:
-
-	$ steam deploy engine
-`
-
-func deploy(c *context) *cobra.Command {
-	cmd := newCmd(c, deployHelp, nil)
-	cmd.AddCommand(deployEngine(c))
-	return cmd
-}
-
-var deployEngineHelp = `
-engine [enginePath]
-Deploy an H2O engine to Steam.
-Examples:
-
-	$ steam deploy engine --file-path=path/to/engine
-`
-
-func deployEngine(c *context) *cobra.Command {
-	var (
-		filePath string
-	)
-	cmd := newCmd(c, deployEngineHelp, func(c *context, args []string) {
-		attrs := map[string]string{
-			"type": fs.KindEngine,
-		}
-
-		if err := c.transmitFile(filePath, attrs); err != nil {
-			log.Fatalln(err)
-		}
-
-		log.Println("Engine deployed:", path.Base(filePath))
-	})
-
-	cmd.Flags().StringVar(&filePath, "file-path", "", "Path to engine")
-
-	return cmd
-}
-
 var uploadHelp = `
 upload [resource-type]
 Upload a resource of the specified type.
@@ -311,15 +268,18 @@ Examples:
 func upload(c *context) *cobra.Command {
 	cmd := newCmd(c, uploadHelp, nil)
 	cmd.AddCommand(uploadFile(c))
+	cmd.AddCommand(uploadEngine(c))
 	return cmd
 }
 
 var uploadFileHelp = `
 file [path]
-Upload an H2O engine to Steam.
+Upload an asset to Steam. 
 Examples:
 
-	$ steam upload engine path/to/engine
+	$ steam upload file \
+		--file-path=? \
+		--project-id=?
 `
 
 func uploadFile(c *context) *cobra.Command {
@@ -356,6 +316,35 @@ func uploadFile(c *context) *cobra.Command {
 	cmd.Flags().Int64Var(&projectId, "project-id", 0, "Target project id")
 	cmd.Flags().StringVar(&packageName, "package-name", "", "Target package")
 	cmd.Flags().StringVar(&relativePath, "relative-path", "", "Relative path to copy file to")
+
+	return cmd
+}
+
+var uploadEngineHelp = `
+engine [path]
+Upload an engine to Steam. 
+Examples:
+
+	$ steam upload engine \
+		--file-path=?
+`
+
+func uploadEngine(c *context) *cobra.Command {
+	var (
+		filePath string
+	)
+	cmd := newCmd(c, uploadEngineHelp, func(c *context, args []string) {
+		attrs := map[string]string{
+			"type": fs.KindEngine,
+		}
+		if err := c.transmitFile(filePath, attrs); err != nil {
+			log.Fatalln(err)
+		}
+
+		log.Println("Engine uploaded:", path.Base(filePath))
+	})
+
+	cmd.Flags().StringVar(&filePath, "file-path", "", "File to be uploaded")
 
 	return cmd
 }

--- a/cli2/main.go
+++ b/cli2/main.go
@@ -114,7 +114,6 @@ func Steam(version, buildDate string, stdout, stderr, trace io.Writer) *cobra.Co
 		login(c),
 		reset(c),
 		serve(c),
-		deploy(c),
 		upload(c),
 	)
 	registerGeneratedCommands(c, cmd)

--- a/gui/src/Proxy/CLI.ts
+++ b/gui/src/Proxy/CLI.ts
@@ -346,11 +346,6 @@ export function deleteService(serviceId: number): void {
   Proxy.Call("DeleteService", req, print);
 }
 
-export function addEngine(engineName: string, enginePath: string): void {
-  const req: any = { engine_name: engineName, engine_path: enginePath };
-  Proxy.Call("AddEngine", req, print);
-}
-
 export function getEngine(engineId: number): void {
   const req: any = { engine_id: engineId };
   Proxy.Call("GetEngine", req, print);

--- a/gui/src/Proxy/Proxy.ts
+++ b/gui/src/Proxy/Proxy.ts
@@ -674,9 +674,6 @@ export interface Service {
   // Delete a service
   deleteService: (serviceId: number, go: (error: Error) => void) => void
   
-  // Add an engine
-  addEngine: (engineName: string, enginePath: string, go: (error: Error, engineId: number) => void) => void
-  
   // Get engine details
   getEngine: (engineId: number, go: (error: Error, engine: Engine) => void) => void
   
@@ -1672,20 +1669,6 @@ interface DeleteServiceIn {
 }
 
 interface DeleteServiceOut {
-  
-}
-
-interface AddEngineIn {
-  
-  engine_name: string
-  
-  engine_path: string
-  
-}
-
-interface AddEngineOut {
-  
-  engine_id: number
   
 }
 
@@ -3090,18 +3073,6 @@ export function deleteService(serviceId: number, go: (error: Error) => void): vo
     } else {
       const d: DeleteServiceOut = <DeleteServiceOut> data;
       return go(null);
-    }
-  });
-}
-
-export function addEngine(engineName: string, enginePath: string, go: (error: Error, engineId: number) => void): void {
-  const req: AddEngineIn = { engine_name: engineName, engine_path: enginePath };
-  Proxy.Call("AddEngine", req, function(error, data) {
-    if (error) {
-      return go(error, null);
-    } else {
-      const d: AddEngineOut = <AddEngineOut> data;
-      return go(null, d.engine_id);
     }
   });
 }

--- a/master/upload.go
+++ b/master/upload.go
@@ -199,7 +199,7 @@ func (s *UploadHandler) handleEngine(w http.ResponseWriter, pz az.Principal, fil
 	}
 
 	// Add Engine to datastore
-	if _, err := s.webService.AddEngine(pz, dstBase, dstPath); err != nil {
+	if _, err := s.ds.CreateEngine(pz, dstBase, dstPath); err != nil {
 		http.Error(w, fmt.Sprintf("Error saving engine to datastore: %v", err), http.StatusInternalServerError)
 		return errors.Wrap(err, "failed saving engine to datastore")
 	}

--- a/master/web/service.go
+++ b/master/web/service.go
@@ -1676,15 +1676,6 @@ func (s *Service) DeleteService(pz az.Principal, serviceId int64) error {
 	return nil
 }
 
-// FIXME this should not be here - not an client-facing API
-func (s *Service) AddEngine(pz az.Principal, engineName, enginePath string) (int64, error) {
-	if err := pz.CheckPermission(s.ds.Permissions.ManageEngine); err != nil {
-		return 0, err
-	}
-
-	return s.ds.CreateEngine(pz, engineName, enginePath)
-}
-
 func (s *Service) GetEngine(pz az.Principal, engineId int64) (*web.Engine, error) {
 	if err := pz.CheckPermission(s.ds.Permissions.ViewEngine); err != nil {
 		return nil, err

--- a/python/steam.py
+++ b/python/steam.py
@@ -1187,24 +1187,6 @@ class RPCClient:
 		response = self.connection.call("DeleteService", request)
 		return 
 	
-	def add_engine(self, engine_name, engine_path):
-		"""
-		Add an engine
-
-		Parameters:
-		engine_name: No description available (string)
-		engine_path: No description available (string)
-
-		Returns:
-		engine_id: No description available (int64)
-		"""
-		request = {
-			'engine_name': engine_name,
-			'engine_path': engine_path
-		}
-		response = self.connection.call("AddEngine", request)
-		return response['engine_id']
-	
 	def get_engine(self, engine_id):
 		"""
 		Get engine details

--- a/srv/web/api/api.go
+++ b/srv/web/api/api.go
@@ -341,7 +341,6 @@ type Service struct {
 	GetServicesForProject         GetServicesForProject         `help:"List services for a project"`
 	GetServicesForModel           GetServicesForModel           `help:"List services for a model"`
 	DeleteService                 DeleteService                 `help:"Delete a service"`
-	AddEngine                     AddEngine                     `help:"Add an engine"`
 	GetEngine                     GetEngine                     `help:"Get engine details"`
 	GetEngines                    GetEngines                    `help:"List engines"`
 	DeleteEngine                  DeleteEngine                  `help:"Delete an engine"`
@@ -742,12 +741,6 @@ type GetServicesForModel struct {
 }
 type DeleteService struct {
 	ServiceId int64
-}
-type AddEngine struct {
-	EngineName string
-	EnginePath string
-	_          int
-	EngineId   int64
 }
 type GetEngine struct {
 	EngineId int64

--- a/srv/web/service.go
+++ b/srv/web/service.go
@@ -352,7 +352,6 @@ type Service interface {
 	GetServicesForProject(pz az.Principal, projectId int64, offset int64, limit int64) ([]*ScoringService, error)
 	GetServicesForModel(pz az.Principal, modelId int64, offset int64, limit int64) ([]*ScoringService, error)
 	DeleteService(pz az.Principal, serviceId int64) error
-	AddEngine(pz az.Principal, engineName string, enginePath string) (int64, error)
 	GetEngine(pz az.Principal, engineId int64) (*Engine, error)
 	GetEngines(pz az.Principal) ([]*Engine, error)
 	DeleteEngine(pz az.Principal, engineId int64) error
@@ -949,15 +948,6 @@ type DeleteServiceIn struct {
 }
 
 type DeleteServiceOut struct {
-}
-
-type AddEngineIn struct {
-	EngineName string `json:"engine_name"`
-	EnginePath string `json:"engine_path"`
-}
-
-type AddEngineOut struct {
-	EngineId int64 `json:"engine_id"`
 }
 
 type GetEngineIn struct {
@@ -2020,16 +2010,6 @@ func (this *Remote) DeleteService(serviceId int64) error {
 		return err
 	}
 	return nil
-}
-
-func (this *Remote) AddEngine(engineName string, enginePath string) (int64, error) {
-	in := AddEngineIn{engineName, enginePath}
-	var out AddEngineOut
-	err := this.Proc.Call("AddEngine", &in, &out)
-	if err != nil {
-		return 0, err
-	}
-	return out.EngineId, nil
 }
 
 func (this *Remote) GetEngine(engineId int64) (*Engine, error) {
@@ -4744,41 +4724,6 @@ func (this *Impl) DeleteService(r *http.Request, in *DeleteServiceIn, out *Delet
 		log.Println(guid, "ERR", pz, name, err)
 		return err
 	}
-
-	res, merr := json.Marshal(out)
-	if merr != nil {
-		log.Println(guid, "RES", pz, name, merr)
-	} else {
-		log.Println(guid, "RES", pz, name, string(res))
-	}
-
-	return nil
-}
-
-func (this *Impl) AddEngine(r *http.Request, in *AddEngineIn, out *AddEngineOut) error {
-	const name = "AddEngine"
-
-	guid := xid.New().String()
-
-	pz, azerr := this.Az.Identify(r)
-	if azerr != nil {
-		return azerr
-	}
-
-	req, merr := json.Marshal(in)
-	if merr != nil {
-		log.Println(guid, "REQ", pz, name, merr)
-	} else {
-		log.Println(guid, "REQ", pz, name, string(req))
-	}
-
-	val0, err := this.Service.AddEngine(pz, in.EngineName, in.EnginePath)
-	if err != nil {
-		log.Println(guid, "ERR", pz, name, err)
-		return err
-	}
-
-	out.EngineId = val0
 
 	res, merr := json.Marshal(out)
 	if merr != nil {


### PR DESCRIPTION
Going forward, `steam upload engine --file-path=?` will be the only
accepted way to upload an engine. `steam upload file ...` will still
be accepted for uploading package assets.