### PR TITLE
Fixes a breaking change introduced by moment > 2.16.0

### DIFF
--- a/gui/package.json
+++ b/gui/package.json
@@ -11,7 +11,7 @@
     "h2oUIKit": "0.2.12",
     "jquery": "^3.0.0",
     "lodash": "^4.13.1",
-    "moment": "^2.14.1",
+    "moment": "2.16.0",
     "react": "^15.3.2",
     "react-dom": "^15.3.2",
     "react-motion": "^0.4.4",


### PR DESCRIPTION
Pins moment@2.16.0 due to a breaking change introduced. More info found [here](https://github.com/moment/moment/issues/3617).