### PR TITLE
Steam 627

### DIFF
--- a/cli2/cli.go
+++ b/cli2/cli.go
@@ -2443,15 +2443,19 @@ func getLdap(c *context) *cobra.Command {
 				log.Fatalln(err)
 			}
 			lines := []string{
-				fmt.Sprintf("Host:\t%v\t", config.Host),                       // No description available
-				fmt.Sprintf("Port:\t%v\t", config.Port),                       // No description available
-				fmt.Sprintf("Ldaps:\t%v\t", config.Ldaps),                     // No description available
-				fmt.Sprintf("BindDn:\t%v\t", config.BindDn),                   // No description available
-				fmt.Sprintf("BindPassword:\t%v\t", config.BindPassword),       // No description available
-				fmt.Sprintf("UserBaseDn:\t%v\t", config.UserBaseDn),           // No description available
-				fmt.Sprintf("UserBaseFilter:\t%v\t", config.UserBaseFilter),   // No description available
-				fmt.Sprintf("UserRnAttribute:\t%v\t", config.UserRnAttribute), // No description available
-				fmt.Sprintf("ForceBind:\t%v\t", config.ForceBind),             // No description available
+				fmt.Sprintf("Host:\t%v\t", config.Host),                                       // No description available
+				fmt.Sprintf("Port:\t%v\t", config.Port),                                       // No description available
+				fmt.Sprintf("Ldaps:\t%v\t", config.Ldaps),                                     // No description available
+				fmt.Sprintf("BindDn:\t%v\t", config.BindDn),                                   // No description available
+				fmt.Sprintf("BindPassword:\t%v\t", config.BindPassword),                       // No description available
+				fmt.Sprintf("UserBaseDn:\t%v\t", config.UserBaseDn),                           // No description available
+				fmt.Sprintf("UserBaseFilter:\t%v\t", config.UserBaseFilter),                   // No description available
+				fmt.Sprintf("UserNameAttribute:\t%v\t", config.UserNameAttribute),             // No description available
+				fmt.Sprintf("GroupDn:\t%v\t", config.GroupDn),                                 // No description available
+				fmt.Sprintf("StaticMemberAttribute:\t%v\t", config.StaticMemberAttribute),     // No description available
+				fmt.Sprintf("SearchRequestSizeLimint:\t%v\t", config.SearchRequestSizeLimint), // No description available
+				fmt.Sprintf("SearchRequestTimeLimit:\t%v\t", config.SearchRequestTimeLimit),   // No description available
+				fmt.Sprintf("ForceBind:\t%v\t", config.ForceBind),                             // No description available
 			}
 			c.printt("Attribute\tValue\t", lines)
 			fmt.Printf("Exists:\t%v\n", exists)

--- a/cli2/cli.go
+++ b/cli2/cli.go
@@ -2443,19 +2443,19 @@ func getLdap(c *context) *cobra.Command {
 				log.Fatalln(err)
 			}
 			lines := []string{
-				fmt.Sprintf("Host:\t%v\t", config.Host),                                       // No description available
-				fmt.Sprintf("Port:\t%v\t", config.Port),                                       // No description available
-				fmt.Sprintf("Ldaps:\t%v\t", config.Ldaps),                                     // No description available
-				fmt.Sprintf("BindDn:\t%v\t", config.BindDn),                                   // No description available
-				fmt.Sprintf("BindPassword:\t%v\t", config.BindPassword),                       // No description available
-				fmt.Sprintf("UserBaseDn:\t%v\t", config.UserBaseDn),                           // No description available
-				fmt.Sprintf("UserBaseFilter:\t%v\t", config.UserBaseFilter),                   // No description available
-				fmt.Sprintf("UserNameAttribute:\t%v\t", config.UserNameAttribute),             // No description available
-				fmt.Sprintf("GroupDn:\t%v\t", config.GroupDn),                                 // No description available
-				fmt.Sprintf("StaticMemberAttribute:\t%v\t", config.StaticMemberAttribute),     // No description available
-				fmt.Sprintf("SearchRequestSizeLimint:\t%v\t", config.SearchRequestSizeLimint), // No description available
-				fmt.Sprintf("SearchRequestTimeLimit:\t%v\t", config.SearchRequestTimeLimit),   // No description available
-				fmt.Sprintf("ForceBind:\t%v\t", config.ForceBind),                             // No description available
+				fmt.Sprintf("Host:\t%v\t", config.Host),                                     // No description available
+				fmt.Sprintf("Port:\t%v\t", config.Port),                                     // No description available
+				fmt.Sprintf("Ldaps:\t%v\t", config.Ldaps),                                   // No description available
+				fmt.Sprintf("BindDn:\t%v\t", config.BindDn),                                 // No description available
+				fmt.Sprintf("BindPassword:\t%v\t", config.BindPassword),                     // No description available
+				fmt.Sprintf("UserBaseDn:\t%v\t", config.UserBaseDn),                         // No description available
+				fmt.Sprintf("UserBaseFilter:\t%v\t", config.UserBaseFilter),                 // No description available
+				fmt.Sprintf("UserNameAttribute:\t%v\t", config.UserNameAttribute),           // No description available
+				fmt.Sprintf("GroupDn:\t%v\t", config.GroupDn),                               // No description available
+				fmt.Sprintf("StaticMemberAttribute:\t%v\t", config.StaticMemberAttribute),   // No description available
+				fmt.Sprintf("SearchRequestSizeLimit:\t%v\t", config.SearchRequestSizeLimit), // No description available
+				fmt.Sprintf("SearchRequestTimeLimit:\t%v\t", config.SearchRequestTimeLimit), // No description available
+				fmt.Sprintf("ForceBind:\t%v\t", config.ForceBind),                           // No description available
 			}
 			c.printt("Attribute\tValue\t", lines)
 			fmt.Printf("Exists:\t%v\n", exists)
@@ -3858,12 +3858,14 @@ Set entities
 Commands:
 
     $ steam set attributes ...
+    $ steam set local ...
 `
 
 func set(c *context) *cobra.Command {
 	cmd := newCmd(c, setHelp, nil)
 
 	cmd.AddCommand(setAttributes(c))
+	cmd.AddCommand(setLocal(c))
 	return cmd
 }
 
@@ -3906,6 +3908,35 @@ func setAttributes(c *context) *cobra.Command {
 	cmd.Flags().StringVar(&attributes, "attributes", attributes, "No description available")
 	cmd.Flags().StringVar(&packageName, "package-name", packageName, "No description available")
 	cmd.Flags().Int64Var(&projectId, "project-id", projectId, "No description available")
+	return cmd
+}
+
+var setLocalHelp = `
+local [?]
+Set Local
+Examples:
+
+    Set security configuration to local
+    $ steam set local --config
+
+`
+
+func setLocal(c *context) *cobra.Command {
+	var config bool // Switch for SetLocalConfig()
+
+	cmd := newCmd(c, setLocalHelp, func(c *context, args []string) {
+		if config { // SetLocalConfig
+
+			// Set security configuration to local
+			err := c.remote.SetLocalConfig()
+			if err != nil {
+				log.Fatalln(err)
+			}
+			return
+		}
+	})
+	cmd.Flags().BoolVar(&config, "config", config, "Set security configuration to local")
+
 	return cmd
 }
 

--- a/gui/src/Proxy/CLI.ts
+++ b/gui/src/Proxy/CLI.ts
@@ -51,6 +51,11 @@ export function checkAdmin(): void {
   Proxy.Call("CheckAdmin", req, print);
 }
 
+export function setLocalConfig(): void {
+  const req: any = {  };
+  Proxy.Call("SetLocalConfig", req, print);
+}
+
 export function setLdapConfig(config: LdapConfig): void {
   const req: any = { config: config };
   Proxy.Call("SetLdapConfig", req, print);

--- a/gui/src/Proxy/Proxy.ts
+++ b/gui/src/Proxy/Proxy.ts
@@ -180,7 +180,11 @@ export interface LdapConfig {
   bind_password: string
   user_base_dn: string
   user_base_filter: string
-  user_rn_attribute: string
+  user_name_attribute: string
+  group_dn: string
+  static_member_attribute: string
+  search_request_size_limint: number
+  search_request_time_limit: number
   force_bind: boolean
 }
 

--- a/gui/src/Proxy/Proxy.ts
+++ b/gui/src/Proxy/Proxy.ts
@@ -183,7 +183,7 @@ export interface LdapConfig {
   user_name_attribute: string
   group_dn: string
   static_member_attribute: string
-  search_request_size_limint: number
+  search_request_size_limit: number
   search_request_time_limit: number
   force_bind: boolean
 }
@@ -337,6 +337,9 @@ export interface Service {
   
   // Check if an identity has admin privileges
   checkAdmin: (go: (error: Error, isAdmin: boolean) => void) => void
+  
+  // Set security configuration to local
+  setLocalConfig: (go: (error: Error) => void) => void
   
   // Set LDAP security configuration
   setLdapConfig: (config: LdapConfig, go: (error: Error) => void) => void
@@ -716,6 +719,14 @@ interface CheckAdminIn {
 interface CheckAdminOut {
   
   is_admin: boolean
+  
+}
+
+interface SetLocalConfigIn {
+  
+}
+
+interface SetLocalConfigOut {
   
 }
 
@@ -2262,6 +2273,18 @@ export function checkAdmin(go: (error: Error, isAdmin: boolean) => void): void {
     } else {
       const d: CheckAdminOut = <CheckAdminOut> data;
       return go(null, d.is_admin);
+    }
+  });
+}
+
+export function setLocalConfig(go: (error: Error) => void): void {
+  const req: SetLocalConfigIn = {  };
+  Proxy.Call("SetLocalConfig", req, function(error, data) {
+    if (error) {
+      return go(error);
+    } else {
+      const d: SetLocalConfigOut = <SetLocalConfigOut> data;
+      return go(null);
     }
   });
 }

--- a/lib/ldap/ldap.go
+++ b/lib/ldap/ldap.go
@@ -188,7 +188,7 @@ func FromConfig(config *web.LdapConfig) *Ldap {
 }
 
 func FromDatabase(ds *data.Datastore) (*Ldap, error) {
-	config, exists, err := ds.ReadSecurity(data.ByKey("ldap"))
+	config, exists, err := ds.ReadAuthentication(data.ByKey("ldap"))
 	if err != nil {
 		return nil, errors.Wrap(err, "reading security config from database")
 	} else if !exists {

--- a/lib/ldap/ldap.go
+++ b/lib/ldap/ldap.go
@@ -20,6 +20,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -35,12 +36,21 @@ type Ldap struct {
 	BindDN   string
 	BindPass string
 
-	UserBaseDn      string
-	UserBaseFilter  string
-	UserRNAttribute string
+	UserBaseDn        string // Location of LDAP users TODO: allow for multiple DNs
+	UserBaseFilter    string // LDAP search filter e.g. (department=IT)
+	UserNameAttribute string // Contains username (typically uid or sAMAccountName)
+
+	GroupDn                 string // The group to allow users from //XXX TEMPORARY
+	GroupBaseDn             string // Location of LDAP group TODO: allow for multiple DNs
+	GroupNameAttribute      string // The attribute that contains the name (typically cn)
+	StaticGroupSearchFilter string // LDAP search filter e.g. (department=IT)
+	StaticMemberAttribute   string // The group member values (typically member or memberUid)
+
+	SearchRequestSizeLimit int // The maximum number of entries request by LDAP searches
+	SearchRequestTimeLimit int // The maximum number of seconds to wait for LDAP searches
 
 	// TODO implement TLS case
-	isTLS     bool
+	Ldaps     bool
 	ForceBind bool
 
 	// Users who are logged in
@@ -48,8 +58,60 @@ type Ldap struct {
 }
 
 func (l *Ldap) Test() error {
-	_, err := ldap.Dial("tcp", l.Address)
-	return errors.Wrap(err, "dialing ldap")
+	conn, err := ldap.Dial("tcp", l.Address)
+	if err != nil {
+		return errors.Wrap(err, "dialing ldap")
+	}
+
+	req := ldap.NewSearchRequest(
+		l.GroupDn, ldap.ScopeBaseObject, ldap.DerefAlways,
+		l.SearchRequestSizeLimit, l.SearchRequestTimeLimit,
+		false,
+		"(objectClass=*)",
+		[]string{l.StaticMemberAttribute}, nil,
+	)
+
+	res, err := conn.Search(req)
+	if err != nil {
+		return errors.Wrap(err, "searching for group")
+	}
+	if len(res.Entries) < 1 {
+		return errors.New(fmt.Sprint("unable to locate group", l.GroupDn))
+	} else if len(res.Entries) > 2 {
+		return errors.New("too many group entries")
+	}
+
+	return nil
+}
+
+func (l *Ldap) checkGroup(conn *ldap.Conn, user string) (bool, error) {
+	req := ldap.NewSearchRequest(
+		l.GroupDn, ldap.ScopeBaseObject, ldap.DerefAlways,
+		l.SearchRequestSizeLimit, l.SearchRequestTimeLimit,
+		false,
+		"(objectClass=*)",
+		[]string{l.StaticMemberAttribute}, nil,
+	)
+
+	res, err := conn.Search(req)
+	if err != nil {
+		return false, errors.Wrap(err, "searching ldap")
+	}
+
+	users := res.Entries[0].GetAttributeValues(l.StaticMemberAttribute)
+	sort.Strings(users)
+	if i := sort.SearchStrings(users, user); i != len(users) {
+		for _, u := range users[i:] {
+			if u == user {
+				return true, nil
+			}
+			if !strings.HasPrefix(u, user) {
+				break
+			}
+		}
+	}
+
+	return false, nil
 }
 
 func (l *Ldap) CheckBind(user, password string) error {
@@ -69,9 +131,8 @@ func (l *Ldap) CheckBind(user, password string) error {
 		ldap.ScopeWholeSubtree, ldap.NeverDerefAliases, 0, 0,
 		false,
 		fmt.Sprintf("(&%s(%s=%s))",
-			l.UserBaseFilter, l.UserRNAttribute, user),
-		nil,
-		nil,
+			l.UserBaseFilter, l.UserNameAttribute, user),
+		nil, nil,
 	)
 	res, err := conn.Search(req)
 	if err != nil {
@@ -82,6 +143,13 @@ func (l *Ldap) CheckBind(user, password string) error {
 	} else if len(res.Entries) > 1 {
 		return fmt.Errorf("too many user entries")
 	}
+
+	if ok, err := l.checkGroup(conn, user); err != nil {
+		return errors.Wrap(err, "checking valid groups")
+	} else if !ok {
+		return errors.New("LDAP user has no valid Steam permissions")
+	}
+
 	userDn := res.Entries[0].DN
 
 	// Verify user Bind
@@ -89,25 +157,34 @@ func (l *Ldap) CheckBind(user, password string) error {
 }
 
 func NewLdap(
-	address, bindDn, bindPass string,
-	userBaseDn, userRNAttribute, userBaseFilter string,
-	forceBind bool,
-	idleTime, maxTime time.Duration) *Ldap {
+	// Connection settings
+	address, bindDn, bindPass string, ldaps, forceBind bool,
+	// User settings
+	userBaseDn, userBaseFilter, userNameAttribute string,
+	// Group settings
+	groupDN, staticMemberAttribute string,
+	// Advanced Settings
+	searchRequestSizeLimit, searchRequestTimeLimit int,
+) *Ldap {
 	return &Ldap{
-		// Base LDAP settings
-		Address: address, BindDN: bindDn, BindPass: bindPass,
-		// User filter settings
-		UserBaseDn: userBaseDn, UserRNAttribute: userRNAttribute, UserBaseFilter: userBaseFilter,
+		// Connection settings
+		Address: address, BindDN: bindDn, BindPass: bindPass, Ldaps: ldaps, ForceBind: forceBind,
+		// User settings
+		UserBaseDn: userBaseDn, UserNameAttribute: userNameAttribute, UserBaseFilter: userBaseFilter,
+		// Group Settings
+		GroupDn: groupDN, StaticMemberAttribute: staticMemberAttribute,
 		// Additional Configs
-		ForceBind: forceBind,
-		Users:     NewLdapUser(idleTime, maxTime),
+		Users: NewLdapUser(time.Minute*1, 2*time.Hour),
 	}
 }
 
 func FromConfig(config *web.LdapConfig) *Ldap {
-	return NewLdap(fmt.Sprintf("%s:%d", config.Host, config.Port), config.BindDn,
-		config.BindPassword, config.UserBaseDn, config.UserRnAttribute, config.UserBaseFilter,
-		config.ForceBind, time.Minute*1, 60*2*time.Minute)
+	return NewLdap(
+		fmt.Sprintf("%s:%d", config.Host, config.Port), config.BindDn, config.BindPassword, config.Ldaps, config.ForceBind,
+		config.UserBaseDn, config.UserBaseFilter, config.UserNameAttribute,
+		config.GroupDn, config.StaticMemberAttribute,
+		0, 0,
+	)
 }
 
 func FromDatabase(ds *data.Datastore) (*Ldap, error) {
@@ -137,9 +214,9 @@ func FromDatabase(ds *data.Datastore) (*Ldap, error) {
 	a := aux.Ldap
 
 	return NewLdap(
-		a.Address,
-		a.BindDN, a.BindPass,
-		a.UserBaseDn, a.UserRNAttribute, a.UserBaseFilter,
-
-		a.ForceBind, time.Minute*1, 60*2*time.Minute), nil
+		a.Address, a.BindDN, a.BindPass, a.Ldaps, a.ForceBind,
+		a.UserBaseDn, a.UserBaseFilter, a.UserNameAttribute,
+		a.GroupDn, a.StaticMemberAttribute,
+		0, 0,
+	), nil
 }

--- a/master/az.go
+++ b/master/az.go
@@ -22,6 +22,8 @@ import (
 	"log"
 	"net/http"
 
+	"github.com/h2oai/steam/master/data"
+
 	auth "github.com/abbot/go-http-auth"
 	"github.com/h2oai/steam/master/az"
 )
@@ -43,6 +45,10 @@ func (a *DefaultAz) Authenticate(username string) string {
 
 	if pz == nil {
 		log.Printf("User %s does not exist\n", username)
+		return ""
+	}
+	if pz.AuthType() != data.LocalAuth {
+		log.Printf("User %s is not enabled through local login\n", username)
 		return ""
 	}
 	return pz.Password()

--- a/master/az/az.go
+++ b/master/az/az.go
@@ -28,6 +28,7 @@ type Principal interface {
 	Password() string
 	IsActive() bool
 	IsAdmin() bool
+	AuthType() string
 	HasPermission(code int64) bool
 	CheckPermission(code int64) error
 	Owns(entityTypeId, entityId int64) (bool, error)

--- a/master/data/constants.go
+++ b/master/data/constants.go
@@ -36,6 +36,10 @@ const (
 
 	// --- Role ---
 	AdminRN = "admin"
+
+	// --- Security --
+	LocalAuth = "local"
+	LDAPAuth  = "ldap"
 )
 
 var cluster_types_list = []string{
@@ -153,7 +157,7 @@ type permission_map struct {
 }
 
 type permission_string_map struct {
-	Id int64
+	Id   int64
 	Desc string
 }
 

--- a/master/data/crud.go
+++ b/master/data/crud.go
@@ -14,6 +14,338 @@ import (
 
 var debug bool
 
+// ---------- -------------- ----------
+// ---------- -------------- ----------
+// ---------- Authentication ----------
+// ---------- -------------- ----------
+// ---------- -------------- ----------
+
+func (ds *Datastore) CreateAuthentication(key, value string, options ...QueryOpt) (int64, error) {
+	tx, err := ds.db.Begin()
+	if err != nil {
+		return 0, errors.Wrap(err, "beginning transaction")
+	}
+
+	var id int64
+	err = tx.Wrap(func() error {
+		// Setup query with optional parameters
+		q := NewQueryConfig(ds, tx, CreateOp, "authentication", nil)
+		// Default insert fields
+		authentication := goqu.Record{
+			"key":   key,
+			"value": value,
+		}
+		q.AddFields(authentication)
+		for _, option := range options {
+			if err := option(q); err != nil {
+				return errors.Wrap(err, "setting up query options")
+			}
+		}
+		if debug {
+			color.Set(color.FgGreen)
+			log.Println(q.dataset.ToInsertSql(q.fields))
+			color.Unset()
+		}
+		// Execute query
+		res, err := q.dataset.Insert(q.fields).Exec()
+		if err != nil {
+			return errors.Wrap(err, "executing query")
+		}
+		id, err = res.LastInsertId()
+		if err != nil {
+			return errors.Wrap(err, "retrieving id")
+		}
+		q.entityId = id
+		for _, post := range q.postFunc {
+			if err := post(q); err != nil {
+				return errors.Wrap(err, "running post functions")
+			}
+		}
+
+		return nil
+	})
+
+	return id, errors.Wrap(err, "committing transaction")
+}
+
+func (ds *Datastore) ReadAuthentications(options ...QueryOpt) ([]Authentication, error) {
+	tx, err := ds.db.Begin()
+	if err != nil {
+		return []Authentication{}, errors.Wrap(err, "beginning transaction")
+	}
+
+	var authentications []Authentication
+	err = tx.Wrap(func() error {
+		// Setup query with optional parameters
+		q := NewQueryConfig(ds, tx, "", "authentication", nil)
+		for _, option := range options {
+			if err := option(q); err != nil {
+				return errors.Wrap(err, "setting up query options")
+			}
+		}
+		if debug {
+			color.Set(color.FgBlue)
+			log.Println(q.dataset.ToSql())
+			color.Unset()
+		}
+		// Execute query
+		rows, err := getRows(tx, q.dataset)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		authentications, err = ScanAuthentications(rows)
+
+		if err != nil {
+			return err
+		}
+		for _, post := range q.postFunc {
+			if err := post(q); err != nil {
+				return errors.Wrap(err, "running post functions")
+			}
+		}
+
+		return nil
+	})
+
+	return authentications, errors.Wrap(err, "committing transaction")
+}
+
+func (ds *Datastore) ReadAuthentication(options ...QueryOpt) (Authentication, bool, error) {
+	tx, err := ds.db.Begin()
+	if err != nil {
+		return Authentication{}, false, errors.Wrap(err, "beginning transaction")
+	}
+
+	var authentication Authentication
+	var exists bool
+	err = tx.Wrap(func() error {
+		// Setup query with optional parameters
+		q := NewQueryConfig(ds, tx, "", "authentication", nil)
+		for _, option := range options {
+			if err := option(q); err != nil {
+				return errors.Wrap(err, "setting up query options")
+			}
+		}
+		if debug {
+			color.Set(color.FgBlue)
+			log.Println(q.dataset.ToSql())
+			color.Unset()
+		}
+		// Execute query
+		row, err := getRow(tx, q.dataset)
+		if err != nil {
+			return err
+		}
+		authentication, err = ScanAuthentication(row)
+		if err == sql.ErrNoRows {
+			return nil
+		} else if err == nil {
+			exists = true
+		}
+		if err != nil {
+			return err
+		}
+		for _, post := range q.postFunc {
+			if err := post(q); err != nil {
+				return errors.Wrap(err, "running post functions")
+			}
+		}
+
+		return nil
+	})
+
+	return authentication, exists, errors.Wrap(err, "committing transaction")
+}
+
+func (ds *Datastore) UpdateAuthentication(authenticationId int64, options ...QueryOpt) error {
+	tx, err := ds.db.Begin()
+	if err != nil {
+		return errors.Wrap(err, "beginning transaction")
+	}
+
+	err = tx.Wrap(func() error {
+		// Setup query with optional parameters
+		q := NewQueryConfig(ds, tx, UpdateOp, "authentication", authenticationId)
+		for _, option := range options {
+			if err := option(q); err != nil {
+				return errors.Wrap(err, "setting up query options")
+			}
+		}
+		if debug && len(q.fields) > 0 {
+			color.Set(color.FgYellow)
+			log.Println(q.dataset.ToUpdateSql(q.fields))
+			color.Unset()
+		}
+		// Execute query
+		if len(q.fields) > 0 {
+			if _, err := q.dataset.Update(q.fields).Exec(); err != nil {
+				return errors.Wrap(err, "executing query")
+			}
+		}
+		for _, post := range q.postFunc {
+			if err := post(q); err != nil {
+				return errors.Wrap(err, "running post functions")
+			}
+		}
+		return nil
+	})
+
+	return errors.Wrap(err, "committing transaction")
+}
+
+func (ds *Datastore) DeleteAuthentication(authenticationId int64, options ...QueryOpt) error {
+	tx, err := ds.db.Begin()
+	if err != nil {
+		return errors.Wrap(err, "beginning transaction")
+	}
+
+	err = tx.Wrap(func() error {
+		// Setup query with optional parameters
+		q := NewQueryConfig(ds, tx, DeleteOp, "authentication", authenticationId)
+		for _, option := range options {
+			if err := option(q); err != nil {
+				return errors.Wrap(err, "setting up query options")
+			}
+		}
+		if debug {
+			color.Set(color.FgRed)
+			log.Println(q.dataset.ToDeleteSql())
+			color.Unset()
+		}
+		// Execute query
+		if _, err := q.dataset.Delete().Exec(); err != nil {
+			return errors.Wrap(err, "executing query")
+		}
+		for _, post := range q.postFunc {
+			if err := post(q); err != nil {
+				return errors.Wrap(err, "running post functions")
+			}
+		}
+		return errors.Wrap(deletePrivilege(tx, ByEntityId(q.entityId), ByEntityTypeId(q.entityTypeId)), "deleting privileges")
+	})
+
+	return errors.Wrap(err, "committing transaction")
+}
+func createAuthentication(tx *goqu.TxDatabase, key, value string, options ...QueryOpt) (int64, error) {
+	// Setup query with optional parameters
+	q := NewQueryConfig(nil, tx, CreateOp, "authentication", nil)
+	// Default insert fields
+	authentication := goqu.Record{
+		"key":   key,
+		"value": value,
+	}
+	q.AddFields(authentication)
+	for _, option := range options {
+		if err := option(q); err != nil {
+			return 0, errors.Wrap(err, "setting up query options")
+		}
+	}
+	if debug {
+		color.Set(color.FgGreen)
+		log.Println(q.dataset.ToInsertSql(q.fields))
+		color.Unset()
+	}
+	// Execute query
+	res, err := q.dataset.Insert(q.fields).Exec()
+	if err != nil {
+		return 0, errors.Wrap(err, "executing query")
+	}
+	return res.LastInsertId()
+}
+
+func readAuthentications(tx *goqu.TxDatabase, options ...QueryOpt) ([]Authentication, error) {
+	// Setup query with optional parameters
+	q := NewQueryConfig(nil, tx, "", "authentication", nil)
+	for _, option := range options {
+		if err := option(q); err != nil {
+			return []Authentication{}, errors.Wrap(err, "setting up query options")
+		}
+	}
+	if debug {
+		color.Set(color.FgBlue)
+		log.Println(q.dataset.ToSql())
+		color.Unset()
+	}
+	// Execute query
+	rows, err := getRows(tx, q.dataset)
+	if err != nil {
+		return []Authentication{}, err
+	}
+	defer rows.Close()
+
+	// Scan rows to Authentications
+	return ScanAuthentications(rows)
+}
+
+func readAuthentication(tx *goqu.TxDatabase, options ...QueryOpt) (Authentication, bool, error) {
+	var exists bool
+	// Setup query with optional parameters
+	q := NewQueryConfig(nil, tx, "", "authentication", nil)
+	for _, option := range options {
+		if err := option(q); err != nil {
+			return Authentication{}, exists, errors.Wrap(err, "setting up query options")
+		}
+	}
+	if debug {
+		color.Set(color.FgBlue)
+		log.Println(q.dataset.ToSql())
+		color.Unset()
+	}
+	// Execute query
+	row, err := getRow(tx, q.dataset)
+	if err != nil {
+		return Authentication{}, false, err
+	}
+	ret_authentication, err := ScanAuthentication(row)
+	if err == sql.ErrNoRows {
+		return Authentication{}, exists, nil
+	} else if err == nil {
+		exists = true
+	}
+	// Scan row to Authentication
+	return ret_authentication, exists, err
+}
+
+func updateAuthentication(tx *goqu.TxDatabase, authenticationId int64, options ...QueryOpt) error {
+	// Setup query with optional parameters
+	q := NewQueryConfig(nil, tx, UpdateOp, "authentication", authenticationId)
+	for _, option := range options {
+		if err := option(q); err != nil {
+			return errors.Wrap(err, "setting up query options")
+		}
+	}
+	if debug && len(q.fields) > 0 {
+		color.Set(color.FgYellow)
+		log.Println(q.dataset.ToUpdateSql(q.fields))
+		color.Unset()
+	}
+	// Execute query
+	if len(q.fields) > 0 {
+		_, err := q.dataset.Update(q.fields).Exec()
+		return errors.Wrap(err, "executing query")
+	}
+	return nil
+}
+
+func deleteAuthentication(tx *goqu.TxDatabase, authenticationId int64, options ...QueryOpt) error {
+	// Setup query with optional parameters
+	q := NewQueryConfig(nil, tx, DeleteOp, "authentication", authenticationId)
+	for _, option := range options {
+		if err := option(q); err != nil {
+			return errors.Wrap(err, "setting up query options")
+		}
+	}
+	if debug {
+		color.Set(color.FgRed)
+		log.Println(q.dataset.ToDeleteSql())
+		color.Unset()
+	}
+	// Execute query
+	_, err := q.dataset.Delete().Exec()
+	return errors.Wrap(err, "executing query")
+}
+
 // ---------- ------------- ----------
 // ---------- ------------- ----------
 // ---------- binomialModel ----------
@@ -5070,338 +5402,6 @@ func updateState(tx *goqu.TxDatabase, stateId int64, options ...QueryOpt) error 
 func deleteState(tx *goqu.TxDatabase, stateId int64, options ...QueryOpt) error {
 	// Setup query with optional parameters
 	q := NewQueryConfig(nil, tx, DeleteOp, "state", stateId)
-	for _, option := range options {
-		if err := option(q); err != nil {
-			return errors.Wrap(err, "setting up query options")
-		}
-	}
-	if debug {
-		color.Set(color.FgRed)
-		log.Println(q.dataset.ToDeleteSql())
-		color.Unset()
-	}
-	// Execute query
-	_, err := q.dataset.Delete().Exec()
-	return errors.Wrap(err, "executing query")
-}
-
-// ---------- -------- ----------
-// ---------- -------- ----------
-// ---------- Security ----------
-// ---------- -------- ----------
-// ---------- -------- ----------
-
-func (ds *Datastore) CreateSecurity(key, value string, options ...QueryOpt) (int64, error) {
-	tx, err := ds.db.Begin()
-	if err != nil {
-		return 0, errors.Wrap(err, "beginning transaction")
-	}
-
-	var id int64
-	err = tx.Wrap(func() error {
-		// Setup query with optional parameters
-		q := NewQueryConfig(ds, tx, CreateOp, "security", nil)
-		// Default insert fields
-		security := goqu.Record{
-			"key":   key,
-			"value": value,
-		}
-		q.AddFields(security)
-		for _, option := range options {
-			if err := option(q); err != nil {
-				return errors.Wrap(err, "setting up query options")
-			}
-		}
-		if debug {
-			color.Set(color.FgGreen)
-			log.Println(q.dataset.ToInsertSql(q.fields))
-			color.Unset()
-		}
-		// Execute query
-		res, err := q.dataset.Insert(q.fields).Exec()
-		if err != nil {
-			return errors.Wrap(err, "executing query")
-		}
-		id, err = res.LastInsertId()
-		if err != nil {
-			return errors.Wrap(err, "retrieving id")
-		}
-		q.entityId = id
-		for _, post := range q.postFunc {
-			if err := post(q); err != nil {
-				return errors.Wrap(err, "running post functions")
-			}
-		}
-
-		return nil
-	})
-
-	return id, errors.Wrap(err, "committing transaction")
-}
-
-func (ds *Datastore) ReadSecurities(options ...QueryOpt) ([]Security, error) {
-	tx, err := ds.db.Begin()
-	if err != nil {
-		return []Security{}, errors.Wrap(err, "beginning transaction")
-	}
-
-	var securities []Security
-	err = tx.Wrap(func() error {
-		// Setup query with optional parameters
-		q := NewQueryConfig(ds, tx, "", "security", nil)
-		for _, option := range options {
-			if err := option(q); err != nil {
-				return errors.Wrap(err, "setting up query options")
-			}
-		}
-		if debug {
-			color.Set(color.FgBlue)
-			log.Println(q.dataset.ToSql())
-			color.Unset()
-		}
-		// Execute query
-		rows, err := getRows(tx, q.dataset)
-		if err != nil {
-			return err
-		}
-		defer rows.Close()
-		securities, err = ScanSecuritys(rows)
-
-		if err != nil {
-			return err
-		}
-		for _, post := range q.postFunc {
-			if err := post(q); err != nil {
-				return errors.Wrap(err, "running post functions")
-			}
-		}
-
-		return nil
-	})
-
-	return securities, errors.Wrap(err, "committing transaction")
-}
-
-func (ds *Datastore) ReadSecurity(options ...QueryOpt) (Security, bool, error) {
-	tx, err := ds.db.Begin()
-	if err != nil {
-		return Security{}, false, errors.Wrap(err, "beginning transaction")
-	}
-
-	var security Security
-	var exists bool
-	err = tx.Wrap(func() error {
-		// Setup query with optional parameters
-		q := NewQueryConfig(ds, tx, "", "security", nil)
-		for _, option := range options {
-			if err := option(q); err != nil {
-				return errors.Wrap(err, "setting up query options")
-			}
-		}
-		if debug {
-			color.Set(color.FgBlue)
-			log.Println(q.dataset.ToSql())
-			color.Unset()
-		}
-		// Execute query
-		row, err := getRow(tx, q.dataset)
-		if err != nil {
-			return err
-		}
-		security, err = ScanSecurity(row)
-		if err == sql.ErrNoRows {
-			return nil
-		} else if err == nil {
-			exists = true
-		}
-		if err != nil {
-			return err
-		}
-		for _, post := range q.postFunc {
-			if err := post(q); err != nil {
-				return errors.Wrap(err, "running post functions")
-			}
-		}
-
-		return nil
-	})
-
-	return security, exists, errors.Wrap(err, "committing transaction")
-}
-
-func (ds *Datastore) UpdateSecurity(securityId int64, options ...QueryOpt) error {
-	tx, err := ds.db.Begin()
-	if err != nil {
-		return errors.Wrap(err, "beginning transaction")
-	}
-
-	err = tx.Wrap(func() error {
-		// Setup query with optional parameters
-		q := NewQueryConfig(ds, tx, UpdateOp, "security", securityId)
-		for _, option := range options {
-			if err := option(q); err != nil {
-				return errors.Wrap(err, "setting up query options")
-			}
-		}
-		if debug && len(q.fields) > 0 {
-			color.Set(color.FgYellow)
-			log.Println(q.dataset.ToUpdateSql(q.fields))
-			color.Unset()
-		}
-		// Execute query
-		if len(q.fields) > 0 {
-			if _, err := q.dataset.Update(q.fields).Exec(); err != nil {
-				return errors.Wrap(err, "executing query")
-			}
-		}
-		for _, post := range q.postFunc {
-			if err := post(q); err != nil {
-				return errors.Wrap(err, "running post functions")
-			}
-		}
-		return nil
-	})
-
-	return errors.Wrap(err, "committing transaction")
-}
-
-func (ds *Datastore) DeleteSecurity(securityId int64, options ...QueryOpt) error {
-	tx, err := ds.db.Begin()
-	if err != nil {
-		return errors.Wrap(err, "beginning transaction")
-	}
-
-	err = tx.Wrap(func() error {
-		// Setup query with optional parameters
-		q := NewQueryConfig(ds, tx, DeleteOp, "security", securityId)
-		for _, option := range options {
-			if err := option(q); err != nil {
-				return errors.Wrap(err, "setting up query options")
-			}
-		}
-		if debug {
-			color.Set(color.FgRed)
-			log.Println(q.dataset.ToDeleteSql())
-			color.Unset()
-		}
-		// Execute query
-		if _, err := q.dataset.Delete().Exec(); err != nil {
-			return errors.Wrap(err, "executing query")
-		}
-		for _, post := range q.postFunc {
-			if err := post(q); err != nil {
-				return errors.Wrap(err, "running post functions")
-			}
-		}
-		return errors.Wrap(deletePrivilege(tx, ByEntityId(q.entityId), ByEntityTypeId(q.entityTypeId)), "deleting privileges")
-	})
-
-	return errors.Wrap(err, "committing transaction")
-}
-func createSecurity(tx *goqu.TxDatabase, key, value string, options ...QueryOpt) (int64, error) {
-	// Setup query with optional parameters
-	q := NewQueryConfig(nil, tx, CreateOp, "security", nil)
-	// Default insert fields
-	security := goqu.Record{
-		"key":   key,
-		"value": value,
-	}
-	q.AddFields(security)
-	for _, option := range options {
-		if err := option(q); err != nil {
-			return 0, errors.Wrap(err, "setting up query options")
-		}
-	}
-	if debug {
-		color.Set(color.FgGreen)
-		log.Println(q.dataset.ToInsertSql(q.fields))
-		color.Unset()
-	}
-	// Execute query
-	res, err := q.dataset.Insert(q.fields).Exec()
-	if err != nil {
-		return 0, errors.Wrap(err, "executing query")
-	}
-	return res.LastInsertId()
-}
-
-func readSecurities(tx *goqu.TxDatabase, options ...QueryOpt) ([]Security, error) {
-	// Setup query with optional parameters
-	q := NewQueryConfig(nil, tx, "", "security", nil)
-	for _, option := range options {
-		if err := option(q); err != nil {
-			return []Security{}, errors.Wrap(err, "setting up query options")
-		}
-	}
-	if debug {
-		color.Set(color.FgBlue)
-		log.Println(q.dataset.ToSql())
-		color.Unset()
-	}
-	// Execute query
-	rows, err := getRows(tx, q.dataset)
-	if err != nil {
-		return []Security{}, err
-	}
-	defer rows.Close()
-
-	// Scan rows to Securities
-	return ScanSecuritys(rows)
-}
-
-func readSecurity(tx *goqu.TxDatabase, options ...QueryOpt) (Security, bool, error) {
-	var exists bool
-	// Setup query with optional parameters
-	q := NewQueryConfig(nil, tx, "", "security", nil)
-	for _, option := range options {
-		if err := option(q); err != nil {
-			return Security{}, exists, errors.Wrap(err, "setting up query options")
-		}
-	}
-	if debug {
-		color.Set(color.FgBlue)
-		log.Println(q.dataset.ToSql())
-		color.Unset()
-	}
-	// Execute query
-	row, err := getRow(tx, q.dataset)
-	if err != nil {
-		return Security{}, false, err
-	}
-	ret_security, err := ScanSecurity(row)
-	if err == sql.ErrNoRows {
-		return Security{}, exists, nil
-	} else if err == nil {
-		exists = true
-	}
-	// Scan row to Security
-	return ret_security, exists, err
-}
-
-func updateSecurity(tx *goqu.TxDatabase, securityId int64, options ...QueryOpt) error {
-	// Setup query with optional parameters
-	q := NewQueryConfig(nil, tx, UpdateOp, "security", securityId)
-	for _, option := range options {
-		if err := option(q); err != nil {
-			return errors.Wrap(err, "setting up query options")
-		}
-	}
-	if debug && len(q.fields) > 0 {
-		color.Set(color.FgYellow)
-		log.Println(q.dataset.ToUpdateSql(q.fields))
-		color.Unset()
-	}
-	// Execute query
-	if len(q.fields) > 0 {
-		_, err := q.dataset.Update(q.fields).Exec()
-		return errors.Wrap(err, "executing query")
-	}
-	return nil
-}
-
-func deleteSecurity(tx *goqu.TxDatabase, securityId int64, options ...QueryOpt) error {
-	// Setup query with optional parameters
-	q := NewQueryConfig(nil, tx, DeleteOp, "security", securityId)
 	for _, option := range options {
 		if err := option(q); err != nil {
 			return errors.Wrap(err, "setting up query options")

--- a/master/data/crud.go
+++ b/master/data/crud.go
@@ -1756,6 +1756,7 @@ func (ds *Datastore) CreateIdentity(name string, options ...QueryOpt) (int64, er
 		// Default insert fields
 		identity := goqu.Record{
 			"name":      name,
+			"auth_type": LocalAuth,
 			"is_active": 1,
 			"created":   time.Now(),
 		}
@@ -1957,6 +1958,7 @@ func createIdentity(tx *goqu.TxDatabase, name string, options ...QueryOpt) (int6
 	// Default insert fields
 	identity := goqu.Record{
 		"name":      name,
+		"auth_type": LocalAuth,
 		"is_active": 1,
 		"created":   time.Now(),
 	}

--- a/master/data/db.go
+++ b/master/data/db.go
@@ -40,8 +40,8 @@ import (
 )
 
 const (
-	VERSION = "1.1.0"
-	standard_user = "standard user"
+	VERSION       = "1.1.0"
+	STANDARD_USER = "standard user"
 )
 
 var standard_user_init_permissions = []string{"ManageCluster", "ViewCluster", "ViewEngine"}
@@ -172,7 +172,6 @@ func NewDatastore(driver string, dbOpts DBOpts) (*Datastore, error) {
 		}
 	}
 
-
 	ds, err := initDatastore(db)
 	if err != nil {
 		return nil, errors.Wrap(err, "initializing datastore")
@@ -282,7 +281,7 @@ func prime(db *goqu.Database) error {
 }
 
 func initRoles(tx *goqu.TxDatabase, permissions []Permission, permissionsToAdd []Permission) error {
-	role, doesRoleExist, err := readRole(tx, ByName(standard_user));
+	role, doesRoleExist, err := readRole(tx, ByName(STANDARD_USER))
 	if err != nil {
 		return errors.Wrapf(err, "error reading role %s", role)
 	}
@@ -293,7 +292,7 @@ func initRoles(tx *goqu.TxDatabase, permissions []Permission, permissionsToAdd [
 		initRolePermissions(tx, role.Id, permissionsToAdd)
 
 	} else {
-		roleId, err := createRole(tx, standard_user)
+		roleId, err := createRole(tx, STANDARD_USER)
 		if err != nil {
 			return errors.Wrapf(err, "error creating role %s", role)
 		}

--- a/master/data/principal.go
+++ b/master/data/principal.go
@@ -56,6 +56,10 @@ func (pz *Principal) IsAdmin() bool {
 	return pz.isAdmin
 }
 
+func (pz *Principal) AuthType() string {
+	return pz.Identity.AuthType
+}
+
 func (pz *Principal) HasPermission(code int64) bool {
 	if pz.IsAdmin() {
 		return true

--- a/master/data/query.go
+++ b/master/data/query.go
@@ -110,7 +110,10 @@ type QueryOpt func(*QueryConfig) error
 // ------------- ------------- -------------
 
 func WithActivity(activate bool) QueryOpt {
-	return func(q *QueryConfig) (err error) { q.fields["is_active"] = activate; return }
+	if activate {
+		return func(q *QueryConfig) (err error) { q.fields["is_active"] = 1; return }
+	}
+	return func(q *QueryConfig) (err error) { q.fields["is_active"] = 0; return }
 }
 
 // ByAddress queries the database for matching address columns
@@ -191,6 +194,18 @@ func WithDefaultIdentityWorkgroup(q *QueryConfig) error {
 // WithDescription adds a description value to the query
 func WithDescription(description string) QueryOpt {
 	return func(q *QueryConfig) (err error) { q.fields["description"] = description; return }
+}
+
+func ByEnabled(q *QueryConfig) (err error) {
+	q.dataset = q.dataset.Where(q.I("enabled").Eq(1))
+	return
+}
+
+func WithEnable(enable bool) QueryOpt {
+	if enable {
+		return func(q *QueryConfig) (err error) { q.fields["enabled"] = 1; return }
+	}
+	return func(q *QueryConfig) (err error) { q.fields["enabled"] = 0; return }
 }
 
 func ForEntity(entityTypeId, entityId int64) QueryOpt {

--- a/master/data/scans.go
+++ b/master/data/scans.go
@@ -4,6 +4,40 @@ package data
 
 import "database/sql"
 
+func ScanAuthentication(r *sql.Row) (Authentication, error) {
+	var s Authentication
+	if err := r.Scan(
+		&s.Id,
+		&s.Key,
+		&s.Value,
+		&s.Enabled,
+	); err != nil {
+		return Authentication{}, err
+	}
+	return s, nil
+}
+
+func ScanAuthentications(rs *sql.Rows) ([]Authentication, error) {
+	structs := make([]Authentication, 0, 16)
+	var err error
+	for rs.Next() {
+		var s Authentication
+		if err = rs.Scan(
+			&s.Id,
+			&s.Key,
+			&s.Value,
+			&s.Enabled,
+		); err != nil {
+			return nil, err
+		}
+		structs = append(structs, s)
+	}
+	if err = rs.Err(); err != nil {
+		return nil, err
+	}
+	return structs, nil
+}
+
 func ScanBinomialModel(r *sql.Row) (binomialModel, error) {
 	var s binomialModel
 	if err := r.Scan(
@@ -775,38 +809,6 @@ func ScanStates(rs *sql.Rows) ([]state, error) {
 		if err = rs.Scan(
 			&s.Id,
 			&s.Name,
-		); err != nil {
-			return nil, err
-		}
-		structs = append(structs, s)
-	}
-	if err = rs.Err(); err != nil {
-		return nil, err
-	}
-	return structs, nil
-}
-
-func ScanSecurity(r *sql.Row) (Security, error) {
-	var s Security
-	if err := r.Scan(
-		&s.Id,
-		&s.Key,
-		&s.Value,
-	); err != nil {
-		return Security{}, err
-	}
-	return s, nil
-}
-
-func ScanSecuritys(rs *sql.Rows) ([]Security, error) {
-	structs := make([]Security, 0, 16)
-	var err error
-	for rs.Next() {
-		var s Security
-		if err = rs.Scan(
-			&s.Id,
-			&s.Key,
-			&s.Value,
 		); err != nil {
 			return nil, err
 		}

--- a/master/data/scans.go
+++ b/master/data/scans.go
@@ -263,6 +263,7 @@ func ScanIdentity(r *sql.Row) (Identity, error) {
 	if err := r.Scan(
 		&s.Id,
 		&s.Name,
+		&s.AuthType,
 		&s.Password,
 		&s.WorkgroupId,
 		&s.IsActive,
@@ -282,6 +283,7 @@ func ScanIdentitys(rs *sql.Rows) ([]Identity, error) {
 		if err = rs.Scan(
 			&s.Id,
 			&s.Name,
+			&s.AuthType,
 			&s.Password,
 			&s.WorkgroupId,
 			&s.IsActive,

--- a/master/data/schema.go
+++ b/master/data/schema.go
@@ -41,6 +41,7 @@ func createSQLiteDB(db *sql.DB) error {
 }
 
 var schema = map[string]string{
+	"authentication":      createTableAuthentication,
 	"binomial_model":      createTableBinomialModel,
 	"cluster":             createTableCluster,
 	"cluster_type":        createTableClusterType,
@@ -61,11 +62,18 @@ var schema = map[string]string{
 	"regression_model":    createTableRegressionModel,
 	"role":                createTableRole,
 	"role_permission":     createTableRolePermission,
-	"security":            createTableSecurity,
-	"service":             createTableService,
 	"state":               createTableState,
 	"workgroup":           createTableWorkgroup,
 }
+
+var createTableAuthentication = `
+CREATE TABLE authentication (
+    id integer PRIMARY KEY AUTOINCREMENT,
+    key text NOT NULL UNIQUE,
+    value texts NOT NULL,
+    enabled boolean UNIQUE
+)
+`
 
 var createTableBinomialModel = `
 CREATE TABLE binomial_model (
@@ -312,14 +320,6 @@ CREATE TABLE role_permission (
     PRIMARY KEY (role_id, permission_id),
     FOREIGN KEY (permission_id) REFERENCES permission(id) ON DELETE CASCADE,
     FOREIGN KEY (role_id) REFERENCES role(id) ON DELETE CASCADE
-)
-`
-
-var createTableSecurity = `
-CREATE TABLE security (
-    id integer PRIMARY KEY AUTOINCREMENT,
-    key text NOT NULL UNIQUE,
-    value texts NOT NULL
 )
 `
 

--- a/master/data/schema.go
+++ b/master/data/schema.go
@@ -154,6 +154,7 @@ var createTableIdentity = `
 CREATE TABLE identity (
     id integer PRIMARY KEY AUTOINCREMENT,
     name text NOT NULL UNIQUE,
+    auth_type test NOT NULL,
     password text,
     workgroup_id integer,
     is_active boolean NOT NULL,

--- a/master/data/tables.go
+++ b/master/data/tables.go
@@ -27,6 +27,13 @@ import (
 	"github.com/lib/pq"
 )
 
+type Authentication struct {
+	Id      int64  `db:"id,pk"`
+	Key     string `db:"key,arg"`
+	Value   string `db:"value,arg"`
+	Enabled bool   `db:"enabled"`
+}
+
 type binomialModel struct {
 	ModelId  int64   `db:"model_id,arg,pk"`
 	Mse      float64 `db:"mse,arg"`
@@ -196,12 +203,6 @@ type rolePermission struct {
 type state struct {
 	Id   int64  `db:"id,pk"`
 	Name string `db:"name,arg"`
-}
-
-type Security struct {
-	Id    int64  `db:"id,pk"`
-	Key   string `db:"key,arg"`
-	Value string `db:"value,arg"`
 }
 
 type Service struct {

--- a/master/data/tables.go
+++ b/master/data/tables.go
@@ -87,6 +87,7 @@ type History struct {
 type Identity struct {
 	Id          int64          `db:"id,pk"`
 	Name        string         `db:"name,arg"`
+	AuthType    string         `db:"auth_type,def=LocalAuth"`
 	Password    sql.NullString `db:"password"`
 	WorkgroupId sql.NullInt64  `db:"workgroup_id"`
 	IsActive    bool           `db:"is_active,def=1"`

--- a/master/ldap_basic_auth.go
+++ b/master/ldap_basic_auth.go
@@ -22,23 +22,25 @@ import (
 
 	"github.com/abbot/go-http-auth"
 	"github.com/h2oai/steam/lib/ldap"
+	"github.com/h2oai/steam/master/data"
 )
 
 type BasicLdapAuthProvider struct {
-	az    *DefaultAz
+	ds    *data.Datastore
 	realm string
 
 	conn *ldap.Ldap
 }
 
 func (p *BasicLdapAuthProvider) Secure(handler http.Handler) http.Handler {
-	authenticator := ldap.NewBasicLdapAuth(p.az, p.az.directory, p.realm, p.conn)
+	az := NewDefaultAz(p.ds)
+	authenticator := ldap.NewBasicLdapAuth(az, az.directory, p.realm, p.conn, p.ds)
 
 	return auth.JustCheck(authenticator, handler.ServeHTTP)
 }
 
-func NewBasicLdapAuthProvider(az *DefaultAz, realm string, conn *ldap.Ldap) *BasicLdapAuthProvider {
-	return &BasicLdapAuthProvider{az: az, realm: realm, conn: conn}
+func NewBasicLdapAuthProvider(ds *data.Datastore, realm string, conn *ldap.Ldap) *BasicLdapAuthProvider {
+	return &BasicLdapAuthProvider{ds: ds, realm: realm, conn: conn}
 }
 
 // Basic/Digest auth have no notion of logouts, so these handlers simply fail auth,

--- a/master/ldap_basic_auth.go
+++ b/master/ldap_basic_auth.go
@@ -25,19 +25,20 @@ import (
 )
 
 type BasicLdapAuthProvider struct {
+	az    *DefaultAz
 	realm string
 
 	conn *ldap.Ldap
 }
 
 func (p *BasicLdapAuthProvider) Secure(handler http.Handler) http.Handler {
-	authenticator := ldap.NewBasicLdapAuth(p.realm, p.conn)
+	authenticator := ldap.NewBasicLdapAuth(p.az, p.az.directory, p.realm, p.conn)
 
 	return auth.JustCheck(authenticator, handler.ServeHTTP)
 }
 
-func NewBasicLdapAuthProvider(realm string, conn *ldap.Ldap) *BasicLdapAuthProvider {
-	return &BasicLdapAuthProvider{realm: realm, conn: conn}
+func NewBasicLdapAuthProvider(az *DefaultAz, realm string, conn *ldap.Ldap) *BasicLdapAuthProvider {
+	return &BasicLdapAuthProvider{az: az, realm: realm, conn: conn}
 }
 
 // Basic/Digest auth have no notion of logouts, so these handlers simply fail auth,

--- a/master/main.go
+++ b/master/main.go
@@ -161,7 +161,7 @@ func Run(version, buildDate string, opts Opts) {
 			log.Fatalln("Invalid configuration:", err)
 		}
 
-		authProvider = NewBasicLdapAuthProvider(defaultAz, webAddress, conn)
+		authProvider = NewBasicLdapAuthProvider(ds, webAddress, conn)
 	default: // "basic"
 		authProvider = newBasicAuthProvider(defaultAz, webAddress)
 	}

--- a/master/main.go
+++ b/master/main.go
@@ -152,10 +152,17 @@ func Run(version, buildDate string, opts Opts) {
 	// --- create basic auth service ---
 	defaultAz := NewDefaultAz(ds)
 	var authProvider AuthProvider
-	switch opts.AuthProvider {
-	case "digest":
+
+	var set string
+	if auth, exists, err := ds.ReadAuthentication(data.ByEnabled); err != nil {
+		log.Fatalln("Reading authentication setting from database:", err)
+	} else if exists {
+		set = auth.Key
+	}
+	switch {
+	case opts.AuthProvider == "digest":
 		authProvider = newDigestAuthProvider(defaultAz, webAddress)
-	case "basic-ldap":
+	case opts.AuthProvider == "basic-ldap", set == data.LDAPAuth:
 		conn, err := ldap.FromDatabase(ds)
 		if err != nil {
 			log.Fatalln("Invalid configuration:", err)

--- a/master/main.go
+++ b/master/main.go
@@ -161,7 +161,7 @@ func Run(version, buildDate string, opts Opts) {
 			log.Fatalln("Invalid configuration:", err)
 		}
 
-		authProvider = NewBasicLdapAuthProvider(webAddress, conn)
+		authProvider = NewBasicLdapAuthProvider(defaultAz, webAddress, conn)
 	default: // "basic"
 		authProvider = newBasicAuthProvider(defaultAz, webAddress)
 	}

--- a/master/web/service.go
+++ b/master/web/service.go
@@ -92,7 +92,7 @@ func (s *Service) GetConfig(pz az.Principal) (*web.Config, error) {
 		Version:             s.version,
 		KerberosEnabled:     s.kerberosEnabled,
 		ClusterProxyAddress: s.clusterProxyAddress,
-		Username: pz.Name(),
+		Username:            pz.Name(),
 	}, nil
 }
 
@@ -1749,7 +1749,7 @@ func (s *Service) LinkIdentityWithRole(pz az.Principal, identityId int64, roleId
 		return errors.New("unable to locate role")
 	}
 	// Link role to identity
-	err := s.ds.UpdateIdentity(identityId, data.LinkRole(roleId),
+	err := s.ds.UpdateIdentity(identityId, data.LinkRole(roleId, false),
 		data.WithLinkAudit(pz),
 	)
 	return errors.Wrap(err, "updating identity in database")

--- a/master/web/service.go
+++ b/master/web/service.go
@@ -2198,11 +2198,13 @@ func (s *Service) GetHistory(pz az.Principal, entityTypeId, entityId int64, offs
 }
 
 type ldapSerialized struct {
-	Address         string
-	Bind            string
-	UserBaseDn      string
-	UserBaseFilter  string
-	UserRnAttribute string
+	Address               string
+	Bind                  string
+	UserBaseDn            string
+	UserBaseFilter        string
+	UserNameAttribute     string
+	GroupDn               string
+	StaticMemberAttribute string
 
 	ForceBind bool
 	Ldaps     bool
@@ -2215,7 +2217,10 @@ func configToSerialized(config *web.LdapConfig) ldapSerialized {
 		bind,
 		config.UserBaseDn,
 		config.UserBaseFilter,
-		config.UserRnAttribute,
+		config.UserNameAttribute,
+		config.GroupDn,
+		config.StaticMemberAttribute,
+
 		config.ForceBind,
 		config.Ldaps,
 	}
@@ -2231,11 +2236,11 @@ func serializedToConfig(config ldapSerialized) (*web.LdapConfig, error) {
 
 	return &web.LdapConfig{
 		Host: host, Port: port,
-		Ldaps:           config.Ldaps,
-		UserBaseDn:      config.UserBaseDn,
-		UserBaseFilter:  config.UserBaseFilter,
-		UserRnAttribute: config.UserRnAttribute,
-		ForceBind:       config.ForceBind,
+		Ldaps:             config.Ldaps,
+		UserBaseDn:        config.UserBaseDn,
+		UserBaseFilter:    config.UserBaseFilter,
+		UserNameAttribute: config.UserNameAttribute,
+		ForceBind:         config.ForceBind,
 	}, nil
 }
 

--- a/python/steam.py
+++ b/python/steam.py
@@ -128,6 +128,19 @@ class RPCClient:
 		response = self.connection.call("CheckAdmin", request)
 		return response['is_admin']
 	
+	def set_local_config(self):
+		"""
+		Set security configuration to local
+
+		Parameters:
+
+		Returns:None
+		"""
+		request = {
+		}
+		response = self.connection.call("SetLocalConfig", request)
+		return 
+	
 	def set_ldap_config(self, config):
 		"""
 		Set LDAP security configuration

--- a/srv/web/api/api.go
+++ b/srv/web/api/api.go
@@ -27,15 +27,19 @@ type Config struct {
 }
 
 type LdapConfig struct {
-	Host            string
-	Port            int
-	Ldaps           bool
-	BindDn          string
-	BindPassword    string
-	UserBaseDn      string
-	UserBaseFilter  string
-	UserRnAttribute string
-	ForceBind       bool
+	Host                    string
+	Port                    int
+	Ldaps                   bool
+	BindDn                  string
+	BindPassword            string
+	UserBaseDn              string
+	UserBaseFilter          string
+	UserNameAttribute       string
+	GroupDn                 string
+	StaticMemberAttribute   string
+	SearchRequestSizeLimint int
+	SearchRequestTimeLimit  int
+	ForceBind               bool
 }
 
 type Cluster struct {
@@ -430,7 +434,7 @@ type GetConfig struct {
 	Config Config `help:"An object containing Steam startup configurations"`
 }
 type CheckAdmin struct {
-	_           int
+	_       int
 	IsAdmin bool
 }
 type SetLdapConfig struct {

--- a/srv/web/api/api.go
+++ b/srv/web/api/api.go
@@ -27,19 +27,19 @@ type Config struct {
 }
 
 type LdapConfig struct {
-	Host                    string
-	Port                    int
-	Ldaps                   bool
-	BindDn                  string
-	BindPassword            string
-	UserBaseDn              string
-	UserBaseFilter          string
-	UserNameAttribute       string
-	GroupDn                 string
-	StaticMemberAttribute   string
-	SearchRequestSizeLimint int
-	SearchRequestTimeLimit  int
-	ForceBind               bool
+	Host                   string
+	Port                   int
+	Ldaps                  bool
+	BindDn                 string
+	BindPassword           string
+	UserBaseDn             string
+	UserBaseFilter         string
+	UserNameAttribute      string
+	GroupDn                string
+	StaticMemberAttribute  string
+	SearchRequestSizeLimit int
+	SearchRequestTimeLimit int
+	ForceBind              bool
 }
 
 type Cluster struct {
@@ -302,6 +302,7 @@ type Service struct {
 	PingServer                    PingServer                    `help:"Ping the Steam server"`
 	GetConfig                     GetConfig                     `help:"Get Steam start up configurations"`
 	CheckAdmin                    CheckAdmin                    `help:"Check if an identity has admin privileges"`
+	SetLocalConfig                SetLocalConfig                `help:"Set security configuration to local"`
 	SetLdapConfig                 SetLdapConfig                 `help:"Set LDAP security configuration"`
 	GetLdapConfig                 GetLdapConfig                 `help:"Get LDAP security configurations"`
 	TestLdapConfig                TestLdapConfig                `help:"Test LDAP security configurations"`
@@ -436,6 +437,8 @@ type GetConfig struct {
 type CheckAdmin struct {
 	_       int
 	IsAdmin bool
+}
+type SetLocalConfig struct {
 }
 type SetLdapConfig struct {
 	Config LdapConfig

--- a/srv/web/service.go
+++ b/srv/web/service.go
@@ -165,15 +165,19 @@ type Label struct {
 }
 
 type LdapConfig struct {
-	Host            string `json:"host"`
-	Port            int    `json:"port"`
-	Ldaps           bool   `json:"ldaps"`
-	BindDn          string `json:"bind_dn"`
-	BindPassword    string `json:"bind_password"`
-	UserBaseDn      string `json:"user_base_dn"`
-	UserBaseFilter  string `json:"user_base_filter"`
-	UserRnAttribute string `json:"user_rn_attribute"`
-	ForceBind       bool   `json:"force_bind"`
+	Host                    string `json:"host"`
+	Port                    int    `json:"port"`
+	Ldaps                   bool   `json:"ldaps"`
+	BindDn                  string `json:"bind_dn"`
+	BindPassword            string `json:"bind_password"`
+	UserBaseDn              string `json:"user_base_dn"`
+	UserBaseFilter          string `json:"user_base_filter"`
+	UserNameAttribute       string `json:"user_name_attribute"`
+	GroupDn                 string `json:"group_dn"`
+	StaticMemberAttribute   string `json:"static_member_attribute"`
+	SearchRequestSizeLimint int    `json:"search_request_size_limint"`
+	SearchRequestTimeLimit  int    `json:"search_request_time_limit"`
+	ForceBind               bool   `json:"force_bind"`
 }
 
 type Model struct {


### PR DESCRIPTION
This commit adds two features:
- Users are split into AuthTypes (currently LDAP/Local); and are authenticated based on this and the current Auth configuration
- LDAP users are now initialized in the DB on login.

TODO:
- LDAP users should be initialized with roles specified by LDAP group mappings to steam roles; currently, all LDAP users become STANDARD_USERS
- Parameters along the main->ldap/user.go chain are fuzzy, this can be cleaned up