### PR TITLE
Adds SSL support to HAproxy

### DIFF
--- a/gui/src/Clusters/Clusters.tsx
+++ b/gui/src/Clusters/Clusters.tsx
@@ -72,7 +72,7 @@ export class Clusters extends React.Component<Props & DispatchProps, any> {
 
   goProxy(cluster) {
     document.cookie = cluster.name + "=" + cluster.token;
-    let url = "https://" + window.location.hostname + ":9999" + cluster.context_path + "flow/index.html";
+    let url = "https://" + window.location.hostname + this.props.config.cluster_proxy_address + cluster.context_path + "flow/index.html";
     window.open(url, "_blank");
   }
 

--- a/gui/src/Clusters/Clusters.tsx
+++ b/gui/src/Clusters/Clusters.tsx
@@ -72,7 +72,7 @@ export class Clusters extends React.Component<Props & DispatchProps, any> {
 
   goProxy(cluster) {
     document.cookie = cluster.name + "=" + cluster.token;
-    let url = "https://" + window.location.hostname + ":443" + cluster.context_path + "flow/index.html";
+    let url = "https://" + window.location.hostname + ":9999" + cluster.context_path + "flow/index.html";
     window.open(url, "_blank");
   }
 

--- a/gui/src/Clusters/Clusters.tsx
+++ b/gui/src/Clusters/Clusters.tsx
@@ -72,7 +72,7 @@ export class Clusters extends React.Component<Props & DispatchProps, any> {
 
   goProxy(cluster) {
     document.cookie = cluster.name + "=" + cluster.token;
-    let url = "http://" + window.location.hostname + ":9999" + cluster.context_path + "flow/index.html";
+    let url = "https://" + window.location.hostname + ":443" + cluster.context_path + "flow/index.html";
     window.open(url, "_blank");
   }
 

--- a/lib/haproxy/haproxy.go
+++ b/lib/haproxy/haproxy.go
@@ -27,7 +27,7 @@ func Reload(clusters []data.Cluster, uid, gid uint32) error {
 			"    option forwardfor\n" +
 			"    option http-server-close\n\n" +
 			"frontend h2o-clusters\n" +
-			"    bind *:443 ssl crt ./steam_haproxy.pem\n" +
+			"    bind *:9999 ssl crt ./steam_haproxy.pem\n" +
 			"    reqadd X-Forwarded-Proto:\\ https\n"
 
 	for _, c := range clusters {

--- a/lib/haproxy/haproxy.go
+++ b/lib/haproxy/haproxy.go
@@ -15,7 +15,7 @@ import (
 	"os"
 )
 
-func Reload(clusters []data.Cluster, uid, gid uint32) error {
+func Reload(clusters []data.Cluster, port, certFilePath string) error {
 	config :=
 		"global\n" +
 			"    daemon\n\n" +
@@ -27,7 +27,7 @@ func Reload(clusters []data.Cluster, uid, gid uint32) error {
 			"    option forwardfor\n" +
 			"    option http-server-close\n\n" +
 			"frontend h2o-clusters\n" +
-			"    bind *:9999 ssl crt ./steam_haproxy.pem\n" +
+			"    bind *" + port + " ssl crt " + certFilePath + "\n" +
 			"    reqadd X-Forwarded-Proto:\\ https\n"
 
 	for _, c := range clusters {

--- a/master/main.go
+++ b/master/main.go
@@ -197,6 +197,7 @@ func Run(version, buildDate string, opts Opts) {
 		predictionServiceHost,
 		opts.ClusterProxyAddress,
 		opts.PredictionServicePorts,
+		opts.WebTLSCertPath,
 		opts.Yarn.KerberosEnabled,
 	)
 	webServiceImpl := &srvweb.Impl{webService, defaultAz}

--- a/master/web/main_test.go
+++ b/master/web/main_test.go
@@ -61,6 +61,7 @@ func testSetup(testType, driver string) (*Service, az.Principal, string) {
 		"",
 		":9001",
 		[2]int{65525, 65535},
+		"",
 		false,
 	)
 

--- a/master/web/service.go
+++ b/master/web/service.go
@@ -45,6 +45,7 @@ import (
 	"github.com/h2oai/steam/srv/h2ov3"
 	"github.com/h2oai/steam/srv/web"
 	"github.com/pkg/errors"
+	"os"
 )
 
 type Service struct {
@@ -204,6 +205,10 @@ func (s *Service) StartClusterOnYarn(pz az.Principal, clusterName string, engine
 		return 0, errors.Wrap(err, "reading engine from database")
 	} else if !exists {
 		return 0, errors.New("unable to locate engine in database")
+	}
+	// Check SSL file
+	if _, err := os.Stat(s.certFilePath); os.IsNotExist(err) {
+		return 0, errors.New("SSL \"" + s.certFilePath + "\" cert file does not exist")
 	}
 	// FIXME implement keytab generation on the fly
 	keytabPath := path.Join(s.workingDir, fs.KTDir, keytab)

--- a/master/web/service.go
+++ b/master/web/service.go
@@ -56,6 +56,7 @@ type Service struct {
 	clusterProxyAddress       string
 	scoringServicePortMin     int
 	scoringServicePortMax     int
+	certFilePath              string
 	kerberosEnabled           bool
 }
 
@@ -64,6 +65,7 @@ func NewService(
 	ds *data.Datastore,
 	compilationServiceAddress, scoringServiceAddress, clusterProxyAddress string,
 	scoringServicePortsRange [2]int,
+	certFilePath string,
 	kerberos bool,
 ) *Service {
 	return &Service{
@@ -71,6 +73,7 @@ func NewService(
 		ds,
 		compilationServiceAddress, scoringServiceAddress, clusterProxyAddress,
 		scoringServicePortsRange[0], scoringServicePortsRange[1],
+		certFilePath,
 		kerberos,
 	}
 }

--- a/master/web/service.go
+++ b/master/web/service.go
@@ -171,8 +171,7 @@ func (s Service) reloadProxyConf(name string) {
 		log.Println("Failed to read clusters.")
 	}
 
-	uid, gid, err := yarn.GetUser(name)
-	if err := haproxy.Reload(clusters, uid, gid); err != nil {
+	if err := haproxy.Reload(clusters, s.clusterProxyAddress, s.certFilePath); err != nil {
 		log.Println("Failed to reload proxy configuration.")
 	}
 }


### PR DESCRIPTION
1) The SSL conf is always added to the HAProxy

2) Cert (`.pem` file) to be used in said conf is passed via `opts.WebTLSCertPath` parameter (shared with Steam's SSL)

3) No cert file/file doesn't exist => starting the cluster will fail

4) Changed the proxy port, it's now configurable via `opts.ClusterProxyAddress` (by default 9001)