### PR TITLE
H2O backend in SSL mode

### DIFF
--- a/lib/haproxy/haproxy.go
+++ b/lib/haproxy/haproxy.go
@@ -38,7 +38,7 @@ frontend h2o-clusters
 backend {{.User}}_{{.Name}}{{if .Toke}}
 	http-request set-header Authorization Basic\ %[req.cook({{.Name}})]
 	redirect scheme https if !{ ssl_fc }{{end}}
-	server {{.User}}_{{.Name}} {{.Addr}}
+	server {{.User}}_{{.Name}} {{.Addr}} ssl verify none
 {{end}}
 `
 

--- a/master/web/service.go
+++ b/master/web/service.go
@@ -217,7 +217,7 @@ func (s *Service) StartClusterOnYarn(pz az.Principal, clusterName string, engine
 	keytabPath := path.Join(s.workingDir, fs.KTDir, keytab)
 	// Start cluster in yarn
 	appId, address, out, token, contextPath, err := yarn.StartCloud(size, s.kerberosEnabled, memory,
-		clusterName, engine.Location, identity.Name, keytabPath, secure)
+		clusterName, engine.Location, identity.Name, keytabPath, s.workingDir, secure)
 	if err != nil {
 		return 0, errors.Wrap(err, "starting yarn cluster")
 	}

--- a/srv/h2ov3/service.go
+++ b/srv/h2ov3/service.go
@@ -31,6 +31,7 @@ import (
 	"github.com/h2oai/steam/bindings"
 	"github.com/h2oai/steam/lib/fs"
 	"github.com/pkg/errors"
+	"crypto/tls"
 )
 
 type H2O struct {
@@ -45,7 +46,7 @@ func NewClient(address, contextPath, token string) *H2O {
 		address,
 		contextPath,
 		token,
-		http.DefaultClient,
+		&http.Client{Transport:&http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}},
 	}
 }
 
@@ -73,7 +74,7 @@ func (h *H2O) url(path string, parms ...interface{}) string {
 		}
 	}
 
-	return (&url.URL{Scheme: "http", Host: h.Address, Path: h.ContextPath + path}).String()
+	return (&url.URL{Scheme: "https", Host: h.Address, Path: h.ContextPath + path}).String()
 }
 
 type H2OException struct {


### PR DESCRIPTION
1) Generates the Java keystore file with a random password

2) Starts H2O clusters in HTTPs mode

3) Removes the keystore file

We might want to give the user the possibility to supply his own java keystore file with a verified cert. In such case the HAProxy conf and the GoLang HTTP client could use modification (enabling verification might be a good idea *but* only if the supplied cert is verified). 