### PR TITLE
added string catching to strMapToRowData

### DIFF
--- a/prediction-service-builder/src/main/webapp/extra/src/PredictPythonServlet.java
+++ b/prediction-service-builder/src/main/webapp/extra/src/PredictPythonServlet.java
@@ -275,8 +275,14 @@ public class PredictPythonServlet extends HttpServlet {
       for (String p : pairs) {
         String[] a = p.split(":");
         String term = a[0];
-        double value = Float.parseFloat(a[1]);
-        row.put(term, value);
+        try {
+          double value = Float.parseFloat(a[1]);
+          row.put(term, value);
+        }
+        catch (NumberFormatException e) {
+          // it wasn't a number so we'll use the string
+          row.put(term, a[1]);
+        }
       }
     }
     catch (NumberFormatException e) {


### PR DESCRIPTION
Recently I asked a question on [Stack Overflow](https://stackoverflow.com/questions/44205039/h2o-steam-prediction-servlet-not-accepting-character-values-from-python-script) detailing an error I'm receiving while trying to use steam with a python pre-processing script. @mstensmo was kind of enough to fix the error but only in the `sparseToRowData` function. This PR simply adds the string catching to the `strMapToRowData` function as well. The model I am using (GBM) defaults to `strMapToRowData` so this uses it in both locations. 