### PR TITLE
Allow registering authenticated H2O clusters.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ build:
 	go build
 
 gui:
-	cd $(GUI) && rm -rf node_modules && npm cache clean && npm install && npm run webpack
+	cd $(GUI) && rm -rf node_modules && npm cache verify && npm install && npm run webpack
 
 guitest:
 	cd $(GUI) && npm test
@@ -149,27 +149,27 @@ debian_package:
 	@echo STEAM_VERSION is $(STEAM_VERSION)
 	@echo STEAM_TAR_GZ is $(STEAM_TAR_GZ)
 	@echo STEAM_TAR_GZ_URL is $(STEAM_TAR_GZ_URL)
-	
+
 	rm -fr tmp
 	mkdir tmp
-	
+
 	rsync -a packaging/debian tmp/
 	sed "s/SUBST_PACKAGE_VERSION/$(STEAM_VERSION)/" packaging/debian/steam/DEBIAN/control > tmp/debian/steam/DEBIAN/control
 	pwd
-	
+
 	(cd tmp && wget $(STEAM_TAR_GZ_URL))
 	pwd
-	
+
 	mkdir -p tmp/debian/steam/opt/h2oai
 	pwd
-	
+
 	(cd tmp/debian/steam/opt/h2oai && tar zxvf ../../../../$(STEAM_TAR_GZ))
 	(cd tmp/debian/steam/opt/h2oai && mv steam-$(STEAM_VERSION)-linux-amd64 steam)
 	pwd
-	
+
 	(cd tmp/debian && dpkg-deb -b steam .)
 	pwd
-	
+
 	mkdir -p target
 	cp -p tmp/debian/steam_$(STEAM_VERSION)_amd64.deb target
 
@@ -177,25 +177,25 @@ rpm_package:
 	@echo STEAM_VERSION is $(STEAM_VERSION)
 	@echo STEAM_TAR_GZ is $(STEAM_TAR_GZ)
 	@echo STEAM_TAR_GZ_URL is $(STEAM_TAR_GZ_URL)
-	
+
 	rm -fr tmp
 	mkdir tmp
-	
+
 	rsync -a packaging/rpm tmp/
 	pwd
-	
+
 	(cd tmp && wget $(STEAM_TAR_GZ_URL))
 	pwd
-	
+
 	mkdir -p tmp/rpm/steam/opt/h2oai
 	pwd
-	
+
 	(cd tmp/rpm/steam/opt/h2oai && tar zxvf ../../../../$(STEAM_TAR_GZ))
 	(cd tmp/rpm/steam/opt/h2oai && mv steam-$(STEAM_VERSION)-linux-amd64 steam)
 	pwd
-	
+
 	(cd tmp/rpm && fpm -s dir -t rpm -n steam -v $(STEAM_VERSION) -C steam)
 	pwd
-	
+
 	mkdir -p target
 	cp -p tmp/rpm/steam-$(STEAM_VERSION)-1.x86_64.rpm target

--- a/cli2/cli.go
+++ b/cli2/cli.go
@@ -2746,7 +2746,7 @@ packages [?]
 Get Packages
 Examples:
 
-    List packages for a project 
+    List packages for a project
     $ steam get packages \
         --project-id=?
 
@@ -3751,13 +3751,17 @@ Examples:
 `
 
 func registerCluster(c *context) *cobra.Command {
-	var address string // No description available
+	var address string  // No description available
+	var username string // No description available
+	var password string // No description available
 
 	cmd := newCmd(c, registerClusterHelp, func(c *context, args []string) {
 
 		// Connect to a cluster
 		clusterId, err := c.remote.RegisterCluster(
-			address, // No description available
+			address,  // No description available
+			username, // No description available
+			password, // No description available
 		)
 		if err != nil {
 			log.Fatalln(err)
@@ -3767,6 +3771,8 @@ func registerCluster(c *context) *cobra.Command {
 	})
 
 	cmd.Flags().StringVar(&address, "address", address, "No description available")
+	cmd.Flags().StringVar(&username, "username", username, "No description available")
+	cmd.Flags().StringVar(&password, "password", password, "No description available")
 	return cmd
 }
 

--- a/master/data/db.go
+++ b/master/data/db.go
@@ -582,7 +582,7 @@ func newDatastore(db *sql.DB) (*Datastore, error) {
 
 func isPrimed(db *sql.DB) (bool, error) {
 	row := db.QueryRow(`
-		SELECT 
+		SELECT
 			count(1)
 		FROM
 			meta
@@ -1178,19 +1178,19 @@ func (ds *Datastore) ReadRoles(pz az.Principal, offset, limit int64) ([]Role, er
 			(
 				SELECT DISTINCT
 					entity_id
-				FROM 
+				FROM
 					privilege
 				WHERE
 				 	$1 OR
 					(
-						workgroup_id IN 
+						workgroup_id IN
 						(
 							SELECT workgroup_id FROM identity_workgroup WHERE identity_id = $2
-						) AND 
+						) AND
 						entity_type_id = $3
 					)
 			)
-		ORDER BY 
+		ORDER BY
 			name
 		LIMIT $4
 		OFFSET $5
@@ -1239,15 +1239,15 @@ func (ds *Datastore) ReadRolesForIdentity(pz az.Principal, identityId int64) ([]
 			(
 				SELECT DISTINCT
 					entity_id
-				FROM 
+				FROM
 					privilege
 				WHERE
 				  $2 OR
 					(
-						workgroup_id IN 
+						workgroup_id IN
 						(
 							SELECT workgroup_id FROM identity_workgroup WHERE identity_id = $3
-						) AND 
+						) AND
 						entity_type_id = $4
 					)
 			)
@@ -1486,12 +1486,12 @@ func (ds *Datastore) ReadWorkgroups(pz az.Principal, offset, limit int64) ([]Wor
 			(
 				SELECT DISTINCT
 					entity_id
-				FROM 
+				FROM
 					privilege
 				WHERE
 				  	$1 OR
 					(
-						workgroup_id IN 
+						workgroup_id IN
 						(
 							SELECT workgroup_id FROM identity_workgroup WHERE identity_id = $2
 						) AND
@@ -1529,15 +1529,15 @@ func (ds *Datastore) ReadWorkgroupsForIdentity(pz az.Principal, identityId int64
 			(
 				SELECT DISTINCT
 					entity_id
-				FROM 
+				FROM
 					privilege
 				WHERE
 				  	$2 OR
 					(
-						workgroup_id IN 
+						workgroup_id IN
 						(
 							SELECT workgroup_id FROM identity_workgroup WHERE identity_id = $3
-						) AND 
+						) AND
 						entity_type_id = $4
 					)
 			)
@@ -1745,15 +1745,15 @@ func (ds *Datastore) ReadIdentities(pz az.Principal, offset, limit int64) ([]Ide
 			(
 				SELECT DISTINCT
 					entity_id
-				FROM 
+				FROM
 					privilege
 				WHERE
 				  	$1 OR
 					(
-						workgroup_id IN 
+						workgroup_id IN
 						(
 							SELECT workgroup_id FROM identity_workgroup WHERE identity_id = $2
-						) AND 
+						) AND
 						entity_type_id = $3
 					)
 			)
@@ -1852,12 +1852,12 @@ func (ds *Datastore) ReadIdentitiesForWorkgroup(pz az.Principal, workgroupId int
 			(
 				SELECT DISTINCT
 					entity_id
-				FROM 
+				FROM
 					privilege
 				WHERE
 					$2 OR
 					(
-						workgroup_id IN 
+						workgroup_id IN
 						(
 							SELECT workgroup_id FROM identity_workgroup WHERE identity_id = $3
 						) AND
@@ -1893,12 +1893,12 @@ func (ds *Datastore) ReadIdentitiesForRole(pz az.Principal, roleId int64) ([]Ide
 			(
 				SELECT DISTINCT
 					entity_id
-				FROM 
+				FROM
 					privilege
 				WHERE
 				  	$2 OR
 					(
-						workgroup_id IN 
+						workgroup_id IN
 						(
 							SELECT workgroup_id FROM identity_workgroup WHERE identity_id = $3
 						) AND
@@ -1919,10 +1919,10 @@ func (ds *Datastore) ReadIdentitiesForRole(pz az.Principal, roleId int64) ([]Ide
 
 func (ds *Datastore) ReadUsersForEntity(pz az.Principal, entityTypeId, entityId int64) ([]IdentityAndRole, error) {
 	rows, err := ds.db.Query(`
-		SELECT 
+		SELECT
 			privilege.privilege_type,
-			identity.id, 
-			identity.name, 
+			identity.id,
+			identity.name,
 			role.id,
 			role.name
 		FROM
@@ -1930,7 +1930,7 @@ func (ds *Datastore) ReadUsersForEntity(pz az.Principal, entityTypeId, entityId 
 			identity_role,
 			privilege,
 			identity_workgroup
-		WHERE 
+		WHERE
 			identity_role.identity_id = identity.id AND
 			identity_role.role_id = role.id AND
 			privilege.workgroup_id = identity_workgroup.workgroup_id AND
@@ -2335,12 +2335,12 @@ func (ds *Datastore) ReadEngines(pz az.Principal) ([]Engine, error) {
 			(
 				SELECT DISTINCT
 					entity_id
-				FROM 
+				FROM
 					privilege
 				WHERE
 				  	$1 OR
 					(
-						workgroup_id IN 
+						workgroup_id IN
 						(
 							SELECT workgroup_id FROM identity_workgroup WHERE identity_id = $2
 						) AND
@@ -2396,16 +2396,16 @@ func (ds *Datastore) DeleteEngine(pz az.Principal, engineId int64) error {
 
 // --- Cluster ---
 
-func (ds *Datastore) CreateExternalCluster(pz az.Principal, name, address, state string) (int64, error) {
+func (ds *Datastore) CreateExternalCluster(pz az.Principal, name, address, username, password, state string) (int64, error) {
 	var id int64
 	err := ds.exec(func(tx *sql.Tx) error {
 		res, err := tx.Exec(`
 			INSERT INTO
 				cluster
-				(name, type_id, detail_id, address, state, created)
+				(name, type_id, detail_id, address, username, password, state, created)
 			VALUES
-				($1,   $2,      0,         $3,      $4,    datetime('now'))
-			`, name, ds.ClusterTypes.External, address, state)
+				($1,   $2,      0,         $3,      $4,       $5,       $6,    datetime('now'))
+			`, name, ds.ClusterTypes.External, address, username, password, state)
 		if err != nil {
 			return err
 		}
@@ -2508,7 +2508,7 @@ func (ds *Datastore) ReadClusterTypes(pz az.Principal) []ClusterType {
 func (ds *Datastore) ReadClusters(pz az.Principal, offset, limit int64) ([]Cluster, error) {
 	rows, err := ds.db.Query(`
 		SELECT
-			id, name, type_id, detail_id, address, state, created
+			id, name, type_id, detail_id, address, username, password, state, created
 		FROM
 			cluster
 		WHERE
@@ -2516,12 +2516,12 @@ func (ds *Datastore) ReadClusters(pz az.Principal, offset, limit int64) ([]Clust
 			(
 				SELECT DISTINCT
 					entity_id
-				FROM 
+				FROM
 					privilege
 				WHERE
 					$1 OR
 					(
-						workgroup_id IN 
+						workgroup_id IN
 						(
 							SELECT workgroup_id FROM identity_workgroup WHERE identity_id = $2
 						) AND
@@ -2547,7 +2547,7 @@ func (ds *Datastore) ReadCluster(pz az.Principal, clusterId int64) (Cluster, err
 	}
 	row := ds.db.QueryRow(`
 		SELECT
-			id, name, type_id, detail_id, address, state, created
+			id, name, type_id, detail_id, address, username, password, state, created
 		FROM
 			cluster
 		WHERE
@@ -2561,7 +2561,7 @@ func (ds *Datastore) ReadClusterByAddress(pz az.Principal, address string) (Clus
 	var cluster Cluster
 	rows, err := ds.db.Query(`
 		SELECT
-			id, name, type_id, detail_id, address, state, created
+			id, name, type_id, detail_id, address, username, password, state, created
 		FROM
 			cluster
 		WHERE
@@ -2580,7 +2580,7 @@ func (ds *Datastore) ReadClusterByName(pz az.Principal, name string) (Cluster, b
 	var cluster Cluster
 	rows, err := ds.db.Query(`
 		SELECT
-			id, name, type_id, detail_id, address, state, created
+			id, name, type_id, detail_id, address, username, password, state, created
 		FROM
 			cluster
 		WHERE
@@ -2737,15 +2737,15 @@ func (ds *Datastore) ReadProjects(pz az.Principal, offset, limit int64) ([]Proje
 			(
 				SELECT DISTINCT
 					entity_id
-				FROM 
+				FROM
 					privilege
 				WHERE
 				  	$1 OR
 					(
-						workgroup_id IN 
+						workgroup_id IN
 						(
 							SELECT workgroup_id FROM identity_workgroup WHERE identity_id = $2
-						) AND 
+						) AND
 						entity_type_id = $3
 					)
 			)
@@ -2862,8 +2862,8 @@ func (ds *Datastore) ReadDatasources(pz az.Principal, projectId, offset, limit i
 						(
 							workgroup_id IN
 							(
-								SELECT 
-									workgroup_id 
+								SELECT
+									workgroup_id
 								FROM
 									identity_workgroup
 								WHERE
@@ -3057,8 +3057,8 @@ func (ds *Datastore) ReadDatasets(pz az.Principal, datasourceId, offset, limit i
 						(
 							workgroup_id IN
 							(
-								SELECT 
-									workgroup_id 
+								SELECT
+									workgroup_id
 								FROM
 									identity_workgroup
 								WHERE
@@ -3367,15 +3367,15 @@ func (ds *Datastore) ReadModels(pz az.Principal, offset, limit int64) ([]Model, 
 			(
 				SELECT DISTINCT
 					entity_id
-				FROM 
+				FROM
 					privilege
 				WHERE
 					$1 OR
 					(
-						workgroup_id IN 
+						workgroup_id IN
 						(
 							SELECT workgroup_id FROM identity_workgroup WHERE identity_id = $2
-						) AND 
+						) AND
 						entity_type_id = $3
 					)
 			)
@@ -3411,12 +3411,12 @@ func (ds *Datastore) ReadModelsForProject(pz az.Principal, projectId, offset, li
 			(
 				SELECT DISTINCT
 					entity_id
-				FROM 
+				FROM
 					privilege
 				WHERE
 				  	$2 OR
 					(
-						workgroup_id IN 
+						workgroup_id IN
 						(
 							SELECT workgroup_id FROM identity_workgroup WHERE identity_id = $3
 						) AND
@@ -3448,7 +3448,7 @@ func (ds *Datastore) CountModelsForProject(pz az.Principal, projectId int64) (in
 			FROM
 				model
 			WHERE
-				project_id = $1	
+				project_id = $1
 			`, projectId)
 
 		return row.Scan(&ct)
@@ -3532,14 +3532,14 @@ func (ds *Datastore) ReadBinomialModels(pz az.Principal, projectId int64, namePa
 			bm.mse, bm.r_squared, bm.logloss, bm.auc, bm.gini
 		FROM
 			model
-		INNER JOIN 
+		INNER JOIN
 			binomial_model bm ON bm.model_id = model.id
 		LEFT OUTER JOIN
 			label ON label.model_id = model.id
 		WHERE
 			model.project_id = $1 AND
 			model.id IN
-			( 
+			(
 				SELECT DISTINCT
 					entity_id
 				FROM
@@ -3547,10 +3547,10 @@ func (ds *Datastore) ReadBinomialModels(pz az.Principal, projectId int64, namePa
 				WHERE
 					$2 OR
 					(
-						workgroup_id IN 
+						workgroup_id IN
 						(
 							SELECT workgroup_id FROM identity_workgroup WHERE identity_id = $3
-							) AND 
+							) AND
 							entity_type_id = $4
 						)
 			) AND
@@ -3582,7 +3582,7 @@ func (ds *Datastore) ReadBinomialModel(pz az.Principal, modelId int64) (Binomial
 
 	row := ds.db.QueryRow(`
 		SELECT
-			model.*, 
+			model.*,
 			label.id,
 			label.name,
 			bm.mse, bm.r_squared, bm.logloss, bm.auc, bm.gini
@@ -3631,7 +3631,7 @@ func (ds *Datastore) ReadMultinomialModels(pz az.Principal, projectId int64, nam
 		WHERE
 			model.project_id = $1 AND
 			model.id IN
-			( 
+			(
 				SELECT DISTINCT
 					entity_id
 				FROM
@@ -3639,10 +3639,10 @@ func (ds *Datastore) ReadMultinomialModels(pz az.Principal, projectId int64, nam
 				WHERE
 					$2 OR
 					(
-						workgroup_id IN 
+						workgroup_id IN
 						(
 							SELECT workgroup_id FROM identity_workgroup WHERE identity_id = $3
-							) AND 
+							) AND
 							entity_type_id = $4
 						)
 			) AND
@@ -3674,13 +3674,13 @@ func (ds *Datastore) ReadMultinomialModel(pz az.Principal, modelId int64) (Multi
 
 	row := ds.db.QueryRow(`
 		SELECT
-			model.*, 
+			model.*,
 			label.id,
 			label.name,
 			mm.mse, mm.r_squared, mm.logloss
 		FROM
 			model
-		INNER JOIN 
+		INNER JOIN
 			multinomial_model mm on mm.model_id = model.id
 		LEFT OUTER JOIN
 			label ON label.model_id = model.id
@@ -3716,14 +3716,14 @@ func (ds *Datastore) ReadRegressionModels(pz az.Principal, projectId int64, name
 			rm.mse, rm.r_squared, rm.mean_residual_deviance
 		FROM
 			model
-		INNER JOIN 
+		INNER JOIN
 			regression_model rm ON rm.model_id = model.id
 		LEFT OUTER JOIN
 			label ON label.model_id = model.id
 		WHERE
 			model.project_id = $1 AND
 			model.id IN
-			( 
+			(
 				SELECT DISTINCT
 					entity_id
 				FROM
@@ -3731,10 +3731,10 @@ func (ds *Datastore) ReadRegressionModels(pz az.Principal, projectId int64, name
 				WHERE
 					$2 OR
 					(
-						workgroup_id IN 
+						workgroup_id IN
 						(
 							SELECT workgroup_id FROM identity_workgroup WHERE identity_id = $3
-							) AND 
+							) AND
 							entity_type_id = $4
 						)
 			) AND
@@ -3766,7 +3766,7 @@ func (ds *Datastore) ReadRegressionModel(pz az.Principal, modelId int64) (Regres
 
 	row := ds.db.QueryRow(`
 		SELECT
-			model.*, 
+			model.*,
 			label.id,
 			label.name,
 			rm.mse, rm.r_squared, rm.mean_residual_deviance
@@ -3837,7 +3837,7 @@ func (ds *Datastore) UpdateModelObjectType(pz az.Principal, modelId int64, typ s
 			SET
 				model_object_type = $1
 			WHERE
-				id = $2	
+				id = $2
 			`, typ, modelId); err != nil {
 			return errors.Wrap(err, "failed executing transaction")
 		}
@@ -4053,15 +4053,15 @@ func (ds *Datastore) ReadLabelsForProject(pz az.Principal, projectId int64) ([]L
 			(
 				SELECT DISTINCT
 					entity_id
-				FROM 
+				FROM
 					privilege
 				WHERE
 					$2 OR
 					(
-						workgroup_id IN 
+						workgroup_id IN
 						(
 							SELECT workgroup_id FROM identity_workgroup WHERE identity_id = $3
-						) AND 
+						) AND
 						entity_type_id = $4
 					)
 			)
@@ -4119,12 +4119,12 @@ func (ds *Datastore) ReadLabel(pz az.Principal, labelId int64) (Label, error) {
 			(
 				SELECT DISTINCT
 					entity_id
-				FROM 
+				FROM
 					privilege
 				WHERE
 					$2 OR
 					(
-						workgroup_id IN 
+						workgroup_id IN
 						(
 							SELECT workgroup_id FROM identity_workgroup WHERE identity_id = $3
 						) AND
@@ -4209,15 +4209,15 @@ func (ds *Datastore) ReadServices(pz az.Principal, offset, limit int64) ([]Servi
 			(
 				SELECT DISTINCT
 					entity_id
-				FROM 
+				FROM
 					privilege
 				WHERE
 					$1 OR
 					(
-						workgroup_id IN 
+						workgroup_id IN
 						(
 							SELECT workgroup_id FROM identity_workgroup WHERE identity_id = $2
-							) AND 
+							) AND
 							entity_type_id = $3
 						)
 			)
@@ -4245,12 +4245,12 @@ func (ds *Datastore) ReadServicesForProjectId(pz az.Principal, projectId, offset
 			(
 				SELECT DISTINCT
 					entity_id
-				FROM 
+				FROM
 					privilege
 				WHERE
 					$2 OR
 					(
-						workgroup_id IN 
+						workgroup_id IN
 						(
 							SELECT workgroup_id FROM identity_workgroup WHERE identity_id = $3
 						) AND

--- a/master/data/models.go
+++ b/master/data/models.go
@@ -123,6 +123,8 @@ type Cluster struct {
 	TypeId   int64
 	DetailId int64
 	Address  string
+	Username string
+	Password string
 	State    string
 	Created  time.Time
 }

--- a/master/data/scans.go
+++ b/master/data/scans.go
@@ -454,6 +454,8 @@ func ScanCluster(r *sql.Row) (Cluster, error) {
 		&s.TypeId,
 		&s.DetailId,
 		&s.Address,
+		&s.Username,
+		&s.Password,
 		&s.State,
 		&s.Created,
 	); err != nil {
@@ -473,6 +475,8 @@ func ScanClusters(rs *sql.Rows) ([]Cluster, error) {
 			&s.TypeId,
 			&s.DetailId,
 			&s.Address,
+			&s.Username,
+			&s.Password,
 			&s.State,
 			&s.Created,
 		); err != nil {

--- a/scripts/database/create-schema.sql
+++ b/scripts/database/create-schema.sql
@@ -101,7 +101,7 @@ CREATE TABLE binomial_model (
     r_squared double precision,
     logloss double precision,
     auc double precision,
-    gini double precision, 
+    gini double precision,
 
     PRIMARY KEY (model_id),
     FOREIGN KEY (model_id) REFERENCES model(id) ON DELETE CASCADE
@@ -141,6 +141,8 @@ CREATE TABLE cluster (
     type_id integer NOT NULL,
     detail_id integer NOT NULL,
     address text NOT NULL,
+    username text NOT NULL,
+    password text NOT NULL,
     state job_state NOT NULL,
     created datetime NOT NULL,
 
@@ -177,7 +179,7 @@ CREATE TABLE cluster (
 
 CREATE TABLE cluster_type (
     id integer PRIMARY KEY AUTOINCREMENT,
-    name text NOT NULL UNIQUE 
+    name text NOT NULL UNIQUE
 );
 
 
@@ -783,7 +785,7 @@ CREATE TABLE project (
     name text NOT NULL,
     description text NOT NULL,
     model_category text NOT NULL,
-    created datetime NOT NULL  
+    created datetime NOT NULL
 );
 
 
@@ -856,7 +858,7 @@ CREATE TABLE role (
     id integer PRIMARY KEY AUTOINCREMENT,
     name text NOT NULL UNIQUE,
     description text NOT NULL,
-    created datetime NOT NULL  
+    created datetime NOT NULL
 );
 
 
@@ -950,7 +952,7 @@ CREATE TABLE workgroup (
     type workgroup_type NOT NULL,
     name text NOT NULL UNIQUE,
     description text NOT NULL,
-    created datetime NOT NULL 
+    created datetime NOT NULL
 );
 
 
@@ -1708,4 +1710,3 @@ CREATE INDEX fki_workgroup_id ON identity (workgroup_id);
 --
 -- PostgreSQL database dump complete
 --
-

--- a/srv/h2ov3/get.go
+++ b/srv/h2ov3/get.go
@@ -37,7 +37,16 @@ func (h *H2O) GetCloudStatus() (*bindings.CloudV3, error) {
 	//@GET
 	u := h.url("/3/Cloud")
 
-	res, err := http.Get(u)
+	client := http.Client{}
+	req, err := http.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, fmt.Errorf("H2O request initialization failed: %s: %s", u, err)
+	}
+	if h.Username != "" && h.Password != "" {
+		req.SetBasicAuth(h.Username, h.Password)
+	}
+
+	res, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("H2O get request failed: %s: %s", u, err)
 	}
@@ -89,7 +98,16 @@ func (h *H2O) GetFramesList() (*bindings.FramesV3, error) {
 	//@GET
 	u := h.url("/3/Frames")
 
-	res, err := http.Get(u)
+	client := http.Client{}
+	req, err := http.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, fmt.Errorf("H2O request initialization failed: %s: %s", u, err)
+	}
+	if h.Username != "" && h.Password != "" {
+		req.SetBasicAuth(h.Username, h.Password)
+	}
+
+	res, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("H2O get request failed: %s: %s", u, err)
 	}

--- a/srv/h2ov3/service.go
+++ b/srv/h2ov3/service.go
@@ -34,12 +34,16 @@ import (
 )
 
 type H2O struct {
-	Address string
+	Address  string
+	Username string
+	Password string
 }
 
-func NewClient(address string) *H2O {
+func NewClient(address string, username string, password string) *H2O {
 	return &H2O{
 		address,
+		username,
+		password,
 	}
 }
 

--- a/srv/web/service.go
+++ b/srv/web/service.go
@@ -292,7 +292,7 @@ type Az interface {
 type Service interface {
 	PingServer(pz az.Principal, input string) (string, error)
 	GetConfig(pz az.Principal) (*Config, error)
-	RegisterCluster(pz az.Principal, address string) (int64, error)
+	RegisterCluster(pz az.Principal, address string, username string, password string) (int64, error)
 	UnregisterCluster(pz az.Principal, clusterId int64) error
 	StartClusterOnYarn(pz az.Principal, clusterName string, engineId int64, size int, memory string, keytab string) (int64, error)
 	StopClusterOnYarn(pz az.Principal, clusterId int64, keytab string) error
@@ -423,7 +423,9 @@ type GetConfigOut struct {
 }
 
 type RegisterClusterIn struct {
-	Address string `json:"address"`
+	Address  string `json:"address"`
+	Username string `json:"username"`
+	Password string `json:"password"`
 }
 
 type RegisterClusterOut struct {
@@ -1412,8 +1414,8 @@ func (this *Remote) GetConfig() (*Config, error) {
 	return out.Config, nil
 }
 
-func (this *Remote) RegisterCluster(address string) (int64, error) {
-	in := RegisterClusterIn{address}
+func (this *Remote) RegisterCluster(address string, username string, password string) (int64, error) {
+	in := RegisterClusterIn{address, username, password}
 	var out RegisterClusterOut
 	err := this.Proc.Call("RegisterCluster", &in, &out)
 	if err != nil {
@@ -2626,7 +2628,7 @@ func (this *Impl) RegisterCluster(r *http.Request, in *RegisterClusterIn, out *R
 		log.Println(guid, "REQ", pz, name, string(req))
 	}
 
-	val0, err := this.Service.RegisterCluster(pz, in.Address)
+	val0, err := this.Service.RegisterCluster(pz, in.Address, in.Username, in.Password)
 	if err != nil {
 		log.Println(guid, "ERR", pz, name, err)
 		return err

--- a/srv/web/service.pipe
+++ b/srv/web/service.pipe
@@ -141,7 +141,7 @@ type Workgroup
 
 Ping(status bool) status bool
 
-RegisterCluster(address string) clusterId int64
+RegisterCluster(address string, username string, password string) clusterId int64
 UnregisterCluster(clusterId int64)
 StartYarnCluster(clusterName string, engineId int64, size int, memory string, username string) clusterId int64 
 StopYarnCluster(clusterId int64)


### PR DESCRIPTION
I apologize in advance for unsolicited pull request, but if possible I would like some advice on whether this is a right approach and maybe I can contribute to the project.

**Use-case** 

I would like to enable authentication on both - H2O and Steam. However, I was unable to find a way for Steam to connect to H2O when (hash) authentication is enabled. 

**This pull request** 

Is a proof-of-concept support for connecting to authenticated H2O cluster.

To see it in action (assuming H2O with authentication is running on `127.0.0.1:54321`):

1. `make` the steam binary
2. `make db`
3. `./steam serve master --superuser-name admin --superuser-password admin123`
4. `./steam login 127.0.0.1:9000 --username admin --password admin123`
5. `./steam register cluster --address 127.0.0.1:54321 --username h2ouser --password h2opass`

Now opening up http://localhost:9000/ should show the cluster in the list:

![screenshot from 2018-03-17 16-45-49](https://user-images.githubusercontent.com/141768/37557861-c3160056-2a02-11e8-9f31-567d6b0283f6.png)

Upon clicking "Connect" it should show list of dataframes, retrieved from H2O cluster with authentication.

**Caveats**

1. The password is stored in the database file in plain text.
2. Currently only `GetDatasetsFromCluster` and `RegisterCluster` functions use authentication.

**Questions**

Does this look like a reasonable approach for the above defined use-case? If so and if this PR has a potential to be merged into master branch, I would be happy to accept your guidance on what would be needed from my side to get it done.

Looking forward to hear back from you.
